### PR TITLE
ORP - Publish sample C code for ORP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,43 @@ Setup:
 
    Windows:
    `> pip3 install six pythoncrc pyserial`
-   
+
    Linux:
    `$ sudo -H pip3 install six pythoncrc pyserial`
 
 Usage:
 
     python orp_test.py [-h] --dev DEV [--b BAUD] [--no-auto-ack]
+
+Where:
+
+    DEV           : serial port name or path (e.g. COM3 on Windows or /dev/ttyUSB0 on Linux)
+    BAUD          : baud rate (default 9600)
+    --no-auto-ack : option to disable automatic acknowledgement of sync and notification packets
+
+For a list of supported commands, type "h" at the prompt
+
+### C
+
+#### orp
+
+A simple binary command-line utilty which can be used to mimic an ORP client, for testing and demonstration.
+
+Depends on:
+- clients/c/src/*
+- clients/c/inc/*
+
+Tested on:
+- Ubuntu 20.04: Python 2.7, 3.8
+
+Build:
+1. Install gcc
+2. cd clients/c
+3. make
+
+Usage:
+
+    ./bin/orp -d DEV -b BAUD
 
 Where:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Depends on:
 - clients/c/inc/*
 
 Tested on:
-- Ubuntu 20.04: Python 2.7, 3.8
+- Ubuntu 20.04
 
 Build:
 1. Install gcc
@@ -71,8 +71,7 @@ Usage:
 
 Where:
 
-    DEV           : serial port name or path (e.g. COM3 on Windows or /dev/ttyUSB0 on Linux)
+    DEV           : serial port name or path (e.g. /dev/ttyUSB0)
     BAUD          : baud rate (default 9600)
-    --no-auto-ack : option to disable automatic acknowledgement of sync and notification packets
 
 For a list of supported commands, type "h" at the prompt

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Tested on:
 - Ubuntu 20.04
 
 Build:
-1. Install gcc
+1. Install gcc (tested with ver 7, 9)
 2. cd clients/c
 3. make
 

--- a/clients/c/Makefile
+++ b/clients/c/Makefile
@@ -1,0 +1,65 @@
+#
+# @file:    Makefile
+#
+# Purpose:  Makefile for example client functions for the Octave Resource Protocol
+#
+# MIT License
+#
+# Copyright (c) 2020 Sierra Wireless Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#----------------------------------------------------------------------------
+
+INC_DIR := inc
+BUILD_DIR := build
+BIN_DIR := bin
+
+CLI_TOOL := orp
+
+CFLAGS = -I$(INC_DIR)
+
+SRCS := main.c commands.c orpProtocol.c hdlc.c orpClient.c orpUtils.c
+OBJS := $(addprefix $(BUILD_DIR)/,$(patsubst %.c,%.o,$(SRCS)))
+
+
+.PHONY:
+command_line_tool: clean $(BIN_DIR)/$(CLI_TOOL)
+
+# Directory creation
+.PRECIOUS: $(BUILD_DIR)/. $(BIN_DIR)/.
+
+$(BUILD_DIR)/.:
+	mkdir -p $@
+
+$(BIN_DIR)/.:
+	mkdir -p $@
+
+.SECONDEXPANSION:
+
+# Build
+$(BUILD_DIR)/%.o: src/%.c | $$(@D)/.
+	$(CC) -c $< -o $@ $(CFLAGS)
+
+$(BIN_DIR)/$(CLI_TOOL): $(OBJS) | $$(@D)/.
+	$(CC) $^ -o $@ $(CFLAGS)
+
+# Clean
+clean:
+	rm -rf $(BUILD_DIR) $(BIN_DIR)

--- a/clients/c/inc/hdlc.h
+++ b/clients/c/inc/hdlc.h
@@ -1,0 +1,195 @@
+/**
+ * @file:    hdlc.h
+ *
+ * Purpose:  Simplified Asynchronous HDLC utilities
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ * Partial HDLC implementation
+ * - Includes framing, escaping, and 16-bit CRC-CCITT
+ * - Does not include Address or control fields, or ACK/NACK
+ *
+ * Usage: (see headers below)
+ *
+ * - hdlc_Pack / hdlc_Unpack routines may be called multiple times on a stream
+ *   of bytes
+ * - hdlc_Init must be called before packing / unpacking each new frame
+ * - hdlc_UnpackDone must be called to check for unpacking complete
+ * - hdlc_PackFinalize must be called to complete packing
+ */
+
+#ifndef HDLC_H_INCLUDE_GUARD
+#define HDLC_H_INCLUDE_GUARD
+
+#include <sys/types.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Defines, Constants
+ */
+//--------------------------------------------------------------------------------------------------
+// Leading 0x7E + 16-bit CRC (possibly escaped to 4 bytes) + trailing 0x7E
+#define HDLC_OVERHEAD_BYTES_COUNT 6
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * HDLC Context structure
+ *
+ * @note This context is used to allow multiple calls to the packing and unpacking functions
+ * in order to support frames or data spanning multiple buffers.  The structure must be
+ * (re) initialized before the start of each packing or unpacking operation
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct
+{
+    int state;
+    int count;
+    uint16_t crc;
+    uint8_t  crcbuf[sizeof(uint16_t)];
+}
+hdlc_context_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * HDLC Error codes
+ *
+ * @note HDLC routines can return these negative values on error
+ */
+//--------------------------------------------------------------------------------------------------
+typedef enum
+{
+    HDLC_ERROR_UNSPECIFIED = -1,       // Do not change this value
+    HDLC_ERROR_CRC         = -2,
+    HDLC_ERROR_FRAME       = -3
+}
+hdlc_error_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Initialize HDLC context
+ *
+ * @note Must be called to reinitialize the HDLC context each time a new frame is to be packed
+ * or unpacked
+ *
+ * @return none
+ */
+//--------------------------------------------------------------------------------------------------
+void hdlc_Init
+(
+    hdlc_context_t *hdlc               // pointer to HDLC context structure
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Unpack an HDLC frame
+ *
+ * @note
+ * - hdlc_Init must be called first, for each new frame to be processed
+ * - Call hdlc_state after each call to hdlc_Unpack to check if unpacking is complete
+ * - May be called multiple times until a complete frame is decoded
+ * - If started in the middle of a frame, will search for <7E> or <7E><7E>
+ *
+ * @return  >= 0 : length data unpacked on this call
+ * @return  <  0 : failure
+ * @return  srclen : IN - count of source bytes to unpack.  OUT - count of source bytes unpacked
+ *
+ * *** The trailing frame byte is NOT included in the count of source bytes unpacked ***
+ */
+//--------------------------------------------------------------------------------------------------
+ssize_t hdlc_Unpack
+(
+    hdlc_context_t *hdlc,              // pointer to HDLC context structure
+    uint8_t        *dest,              // pointer to first empty byte of destination buffer
+    size_t          destlen,           // number of data bytes to unframe into destination
+    uint8_t        *src,               // pointer to first unprocessed byte of source (frame) buffer
+    size_t         *srclen             // number of bytes in, or processed-from, the source buffer
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Check whether HDLC unpacking is complete
+ *
+ * @return true: complete, false: not complete
+ */
+//--------------------------------------------------------------------------------------------------
+bool hdlc_UnpackDone
+(
+    hdlc_context_t *hdlc
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Pack an HDLC frame
+ *
+ * @note
+ * - hdlc_Init must be called first, for each new frame to be encoded
+ * - May be called multiple times until a complete frame is encoded
+ * - hdlc_PackFinalize must be called to finalize the encoding, after all data is processed
+ *
+ * @return  >= 0 : number of bytes added to frame on this call
+ * @return  <  0 : failure
+ * @return  srclen : IN- bytes of data to pack.  OUT - bytes actually packed
+ */
+//--------------------------------------------------------------------------------------------------
+ssize_t hdlc_Pack
+(
+    hdlc_context_t *hdlc,              // pointer to HDLC context structure
+    uint8_t        *dest,              // pointer to first empty byte of destination buffer
+    size_t          destlen,           // number of data bytes to frame into destination
+    uint8_t        *src,               // pointer to first unprocessed byte of source buffer
+    size_t         *srclen             // number of bytes-in / processed-from the source buffer
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Complete HDLC packing - call to complete packing, after all data has been processed
+ *
+ * @return  >= 0 : number of bytes added to frame by the finalize operation: CRC, any required
+ *                 escape characters, and the final frame delimiter 0x7E
+ * @return  <  0 : failure
+ */
+//--------------------------------------------------------------------------------------------------
+ssize_t hdlc_PackFinalize
+(
+    hdlc_context_t *hdlc,
+    uint8_t        *dest,
+    size_t          destlen
+);
+
+
+#endif // HDLC_H_INCLUDE_GUARD
+

--- a/clients/c/inc/legato.h
+++ b/clients/c/inc/legato.h
@@ -1,0 +1,108 @@
+/**
+ * @file:    legato.h
+ *
+ * Purpose:  Minimal set of definitions required to compile the orp files
+ *           independent of the Legato project
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ * The definitions provided here are not necessarily the same as those in
+ * Legato project.  See:  https://github.com/legatoproject/legato-af
+ *
+ */
+#ifndef LEGATO_H_INCLUDE_GUARD
+#define LEGATO_H_INCLUDE_GUARD
+
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#ifndef LE_DEBUG
+#define LE_DEBUG(format, ...) {}
+//#define LE_DEBUG(format, ...) printf("DBUG | " __FILE__ ", line: %u | " format "\r\n", __LINE__, ##__VA_ARGS__)
+#endif
+
+#ifndef LE_INFO
+#define LE_INFO(format, ...)  printf("INFO | " __FILE__ ", line: %u | " format "\r\n", __LINE__, ##__VA_ARGS__)
+#endif
+
+#ifndef LE_WARN
+#define LE_WARN(format, ...)  printf("WARN | " __FILE__ ", line: %u | " format "\r\n", __LINE__, ##__VA_ARGS__)
+#endif
+
+#ifndef LE_ERROR
+#define LE_ERROR(format, ...) printf("ERRO | " __FILE__ ", line: %u | " format "\r\n", __LINE__, ##__VA_ARGS__)
+#endif
+
+#ifndef LE_CRIT
+#define LE_CRIT(format, ...)  printf("CRIT | " __FILE__ ", line: %u | " format "\r\n", __LINE__, ##__VA_ARGS__)
+#endif
+
+#ifndef LE_FATAL
+#define LE_FATAL(format, ...) do { \
+                                  printf("FATAL | " __FILE__ ", line: %u | " format "\r\n", __LINE__, ##__VA_ARGS__); \
+                                  abort(); \
+                              } while(0)
+#endif
+
+#ifndef LE_ASSERT
+#define LE_ASSERT(condition)  do { \
+                                  if (!condition) LE_FATAL("Assert Failed: '%s'", #condition);\
+                              } while(0)
+#endif
+
+typedef enum
+{
+    LE_OK = 0,                  ///< Successful.
+    LE_NOT_FOUND = -1,          ///< Referenced item does not exist or could not be found.
+    LE_NOT_POSSIBLE = -2,       ///< @deprecated It is not possible to perform the requested action.
+    LE_OUT_OF_RANGE = -3,       ///< An index or other value is out of range.
+    LE_NO_MEMORY = -4,          ///< Insufficient memory is available.
+    LE_NOT_PERMITTED = -5,      ///< Current user does not have permission to perform requested action.
+    LE_FAULT = -6,              ///< Unspecified internal error.
+    LE_COMM_ERROR = -7,         ///< Communications error.
+    LE_TIMEOUT = -8,            ///< A time-out occurred.
+    LE_OVERFLOW = -9,           ///< An overflow occurred or would have occurred.
+    LE_UNDERFLOW = -10,         ///< An underflow occurred or would have occurred.
+    LE_WOULD_BLOCK = -11,       ///< Would have blocked if non-blocking behaviour was not requested.
+    LE_DEADLOCK = -12,          ///< Would have caused a deadlock.
+    LE_FORMAT_ERROR = -13,      ///< Format error.
+    LE_DUPLICATE = -14,         ///< Duplicate entry found or operation already performed.
+    LE_BAD_PARAMETER = -15,     ///< Parameter is invalid.
+    LE_CLOSED = -16,            ///< The resource is closed.
+    LE_BUSY = -17,              ///< The resource is busy.
+    LE_UNSUPPORTED = -18,       ///< The underlying resource does not support this operation.
+    LE_IO_ERROR = -19,          ///< An IO operation failed.
+    LE_NOT_IMPLEMENTED = -20,   ///< Unimplemented functionality.
+    LE_UNAVAILABLE = -21,       ///< A transient or temporary loss of a service or resource.
+    LE_TERMINATED = -22,        ///< The process, operation, data stream, session, etc. has stopped.
+    LE_IN_PROGRESS = -23,       ///< The operation is in progress.
+    LE_SUSPENDED = -24,         ///< The operation is suspended.
+}
+le_result_t;
+
+#endif // LEGATO_H_INCLUDE_GUARD

--- a/clients/c/inc/orpClient.h
+++ b/clients/c/inc/orpClient.h
@@ -1,0 +1,187 @@
+/**
+ * @file:    orpClient.h
+ *
+ * Purpose:  Example client functions for the Octave Resource Protocol
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ */
+
+#ifndef ORP_CLIENT_H_INCLUDE_GUARD
+#define ORP_CLIENT_H_INCLUDE_GUARD
+
+#include <stdbool.h>
+#include "orpProtocol.h"
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Initialze internal data for the client
+ *
+ * @param:  fileDescriptor: An open file descriptor for reading and writing framed ORP packets
+ */
+//--------------------------------------------------------------------------------------------------
+bool orp_ClientInit
+(
+    int fileDescriptor
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Receive and process incoming data on the registered file descriptor
+ *
+ * @note:  The client does not monitor the file descriptor for incoming data.  It is the
+ *         responsibility of the layer above to call this function when data is available
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_ClientReceive
+(
+    void
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create a resource in the Data Hub
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_CreateResource
+(
+    bool isInput,
+    const char *path,
+    enum orp_IoDataType dataType,
+    const char *units
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Delete a resource
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_DeleteResource
+(
+    const char *path
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Register for notifications on a resource
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_AddPushHandler
+(
+    const char *path
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Deregister for notifications on a resource
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_RemovePushHandler
+(
+    const char *path
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a string-encoded data sample
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_Push
+(
+    const char *path,
+    enum orp_IoDataType dataType,
+    double timestamp,
+    const char *value
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Request a string-encoded data sample
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_Get
+(
+    const char *path
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the example value for a JSON-type Input resource
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_SetJsonExample
+(
+    const char *path,
+    const char *example
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create a sensor construct in the Data Hub
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_CreateSensor
+(
+    const char *path,
+    enum orp_IoDataType dataType,
+    const char *units
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Delete a sensor
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_DestroySensor
+(
+    const char *path
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Respond to a notification or unsolicited packet
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_Respond
+(
+    enum orp_PacketType type,
+    int status
+);
+
+#endif // ORP_CLIENT_H_INCLUDE_GUARD

--- a/clients/c/inc/orpProtocol.h
+++ b/clients/c/inc/orpProtocol.h
@@ -1,0 +1,275 @@
+/**
+ * @file:    orpProtocol.h
+ *
+ * Purpose:  Octave Resource Protocol packet encoding and decoding functions
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ * Refer to the Octave Resource Protocol description here:
+ * https://docs.octave.dev/docs/octave-resource-protocol
+ *
+ */
+
+#ifndef ORP_PROTOCOL_H_INCLUDE_GUARD
+#define ORP_PROTOCOL_H_INCLUDE_GUARD
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+
+/* The following defines are taken from the Datahub io.api file for the WP77 familly.  These
+ * should be replaced if building in a legato environment, or building to work with a different
+ * Octave device.
+ */
+#if 1
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum number of bytes (excluding null terminator) in an I/O resource's path within its
+ * namespace in the Data Hub's resource tree.
+ */
+//--------------------------------------------------------------------------------------------------
+#define IO_MAX_RESOURCE_PATH_LEN  79
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum number of bytes (excluding terminator) in the value of a string type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+#define IO_MAX_STRING_VALUE_LEN  50000
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum number of bytes (excluding terminator) in the units string of a numeric I/O resource.
+ */
+//--------------------------------------------------------------------------------------------------
+#define IO_MAX_UNITS_NAME_LEN  23
+#endif // Datahub io.api definitions
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum field sizes in the protocol
+ */
+//--------------------------------------------------------------------------------------------------
+
+/* Maximum combined size of protocol fields, not including the actual resource path,
+ * timestamp, data, or units
+ *
+ * Examples:
+ *     Create: <packet type[1]><data type[1]><segment[2]>P<path>[,U<units>]
+ *             1 + 1 + 2 + P + ,U      = 7
+ *
+ *     Push:   <packet type[1]><data type[1]><segment[2]>P<path>[,T<timestamp>][,D<data>]
+ *             1 + 1 + 2 + P + ,T + ,D = 9
+ */
+#define ORP_PROTOCOL_OVERHEAD_LEN_MAX   9
+
+// The maximum sizes of <path>, <units>, and <timestamp>
+#define ORP_PROTOCOL_PATH_LEN_MAX       IO_MAX_RESOURCE_PATH_LEN
+#define ORP_PROTOCOL_UNITS_LEN_MAX      IO_MAX_UNITS_NAME_LEN
+#define ORP_PROTOCOL_TIMESTAMP_LEN_MAX  17  // string representation: 0000000000.000000
+
+// Maximum size of a protocol packet, before accounting for data
+#define ORP_PROTOCOL_LEN_NO_DATA_MAX    (  ORP_PROTOCOL_OVERHEAD_LEN_MAX \
+                                         + ORP_PROTOCOL_PATH_LEN_MAX \
+                                         + ORP_PROTOCOL_UNITS_LEN_MAX \
+                                         + ORP_PROTOCOL_TIMESTAMP_LEN_MAX )
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Supported protocol versions
+ */
+//--------------------------------------------------------------------------------------------------
+enum orp_ProtocolVersion
+{
+    ORP_PROTOCOL_V1 = 0,
+    ORP_PROTOCOL_V2 = 1,
+    ORP_PROTOCOL_COUNT,
+};
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Packet types
+ */
+//--------------------------------------------------------------------------------------------------
+#define ORP_RESPONSE_MASK 0x10
+enum orp_PacketType
+{
+    ORP_PACKET_TYPE_UNKNOWN = 0,
+
+    ORP_RQST_INPUT_CREATE   = 1,
+    ORP_RESP_INPUT_CREATE   = ORP_RQST_INPUT_CREATE  | ORP_RESPONSE_MASK,
+
+    ORP_RQST_OUTPUT_CREATE  = 2,
+    ORP_RESP_OUTPUT_CREATE  = ORP_RQST_OUTPUT_CREATE | ORP_RESPONSE_MASK,
+
+    ORP_RQST_DELETE         = 3,
+    ORP_RESP_DELETE         = ORP_RQST_DELETE        | ORP_RESPONSE_MASK,
+
+    ORP_RQST_HANDLER_ADD    = 4,
+    ORP_RESP_HANDLER_ADD    = ORP_RQST_HANDLER_ADD   | ORP_RESPONSE_MASK,
+
+    ORP_RQST_HANDLER_REM    = 5,
+    ORP_RESP_HANDLER_REM    = ORP_RQST_HANDLER_REM   | ORP_RESPONSE_MASK,
+
+    ORP_RQST_PUSH           = 6,
+    ORP_RESP_PUSH           = ORP_RQST_PUSH          | ORP_RESPONSE_MASK,
+
+    ORP_RQST_GET            = 7,
+    ORP_RESP_GET            = ORP_RQST_GET           | ORP_RESPONSE_MASK,
+
+    ORP_RQST_EXAMPLE_SET    = 8,
+    ORP_RESP_EXAMPLE_SET    = ORP_RQST_EXAMPLE_SET   | ORP_RESPONSE_MASK,
+
+    ORP_RQST_SENSOR_CREATE  = 9,
+    ORP_RESP_SENSOR_CREATE  = ORP_RQST_SENSOR_CREATE | ORP_RESPONSE_MASK,
+
+    ORP_RQST_SENSOR_REMOVE  = 10,
+    ORP_RESP_SENSOR_REMOVE  = ORP_RQST_SENSOR_REMOVE | ORP_RESPONSE_MASK,
+
+    ORP_NTFY_HANDLER_CALL   = 11,
+    ORP_RESP_HANDLER_CALL   = ORP_NTFY_HANDLER_CALL  | ORP_RESPONSE_MASK,
+
+    ORP_NTFY_SENSOR_CALL    = 12,
+    ORP_RESP_SENSOR_CALL    = ORP_NTFY_SENSOR_CALL   | ORP_RESPONSE_MASK,
+
+    ORP_SYNC_SYN            = 13,
+    ORP_SYNC_SYNACK         = 14,
+    ORP_SYNC_ACK            = 15,
+
+    ORP_RESP_UNKNOWN_RQST   = 128                    | ORP_RESPONSE_MASK,
+};
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Resource data types
+ */
+//--------------------------------------------------------------------------------------------------
+enum orp_IoDataType
+{
+    ORP_IO_DATA_TYPE_TRIGGER = 0,  ///< trigger
+    ORP_IO_DATA_TYPE_BOOLEAN = 1,  ///< Boolean
+    ORP_IO_DATA_TYPE_NUMERIC = 2,  ///< numeric (floating point number)
+    ORP_IO_DATA_TYPE_STRING  = 3,  ///< string
+    ORP_IO_DATA_TYPE_JSON    = 4,  ///< JSON
+};
+
+#define  ORP_IO_DATA_TYPE_UNDEF  (-1)
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Message structure
+ */
+//--------------------------------------------------------------------------------------------------
+struct orp_Message
+{
+    enum orp_PacketType         type;          ///< Type of ORP packet
+    enum orp_IoDataType         dataType;      ///< Data type of resource
+    uint16_t                    sequenceNum;   ///< Number of this packet (16-bit rollover)
+    short                       version;       ///< Protocol version (sync packets only)
+    unsigned int                status;        ///< Status of a response
+    double                      timestamp;     ///< Timestamp read/write
+    const char                 *path;          ///< Resource path
+    const char                 *unit;          ///< Resource units
+    void                       *data;          ///< Data (binary permitted)
+    size_t                      dataLen;       ///< Data length
+    int                         sentCount;     ///< Sent packet count (sync packets only)
+    int                         receivedCount; ///< Received packet count (sync packets only)
+};
+
+#define  ORP_TIMESTAMP_INVALID   ((double)(-1))
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Packet decode function:  Packet -> Message structure
+ */
+//--------------------------------------------------------------------------------------------------
+typedef bool (*orp_ProtocolDecode_t)
+(
+    uint8_t *packetBuffer,             ///< IN : Unframed ORP packet
+    size_t   packetLength,             ///< IN : Unframed ORP packet length
+    struct orp_Message *request        ///< OUT: Message structure
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Message encode function:  Message structure -> Packet
+ */
+//--------------------------------------------------------------------------------------------------
+typedef bool (*orp_ProtocolEncode_t)
+(
+    uint8_t *packetBuffer,             ///< OUT: Unframed ORP packet
+    size_t  *packetLength,             ///< IN/OUT: Packet max length / packet length
+    struct orp_Message *response       ///< IN : Message structure
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Structure to access protocol functions
+ */
+//--------------------------------------------------------------------------------------------------
+struct orp_ProtocolCodec
+{
+    enum orp_ProtocolVersion version;
+    orp_ProtocolDecode_t     decode;
+    orp_ProtocolEncode_t     encode;
+};
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Initialize protocol interface
+ */
+//--------------------------------------------------------------------------------------------------
+bool orp_ProtocolClientInit
+(
+    enum orp_ProtocolVersion  version,
+    struct orp_ProtocolCodec *interface
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Initialize an outbound message
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_MessageInit
+(
+    struct orp_Message  *message,
+    enum orp_PacketType  type,
+    unsigned int         status
+);
+
+#endif // ORP_PROTOCOL_H_INCLUDE_GUARD

--- a/clients/c/inc/orpUtils.h
+++ b/clients/c/inc/orpUtils.h
@@ -1,0 +1,49 @@
+/**
+ * @file:    orpUtils.h
+ *
+ * Purpose:  Utility functions for the Octave Resource Protocol
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ */
+
+#ifndef ORP_UTILS_H_INCLUDE_GUARD
+#define ORP_UTILS_H_INCLUDE_GUARD
+
+#include "orpProtocol.h"
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Print the fields of an ORP message structure (template)
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_MessagePrint
+(
+    struct orp_Message *message
+);
+
+#endif // ORP_UTILS_H_INCLUDE_GUARD

--- a/clients/c/src/commands.c
+++ b/clients/c/src/commands.c
@@ -364,7 +364,7 @@ static void commandExample(char *args)
 }
 
 /* Respond to a notification or unsolicited packet
- * > reply resource| <status>
+ * > reply resource|sensor|syn|synack <status>
  */
 static void commandRespond(char *args)
 {

--- a/clients/c/src/commands.c
+++ b/clients/c/src/commands.c
@@ -1,0 +1,440 @@
+/**
+ * @file:    commands.c
+ *
+ * Purpose:  Command-line utility to exercise Octave Resource Protocol example
+ * client code
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <ctype.h>
+#include "orpClient.h"
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Help message
+ */
+//--------------------------------------------------------------------------------------------------
+const char helpStr[] =
+"Syntax:\n\
+\thelp\n\
+\tquit\n\
+\tcreate input|output|sensor  trig|bool|num|str|json <path> [<units>]\n\
+\tdelete resource|handler|sensor <path>\n\
+\tadd handler <path>\n\
+\tpush trig|bool|num|str|json <path> <timestamp> [<data>] (note: if <timestamp> = 0, current timestamp will be used)\n\
+\tget <path>\n\
+\texample json <path> [<data>]\n\
+\treply handler|sensor|sync <status>\n\
+";
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Command look up and argument parsing
+ */
+//--------------------------------------------------------------------------------------------------
+enum commandTypeE {
+    ORPCLI_CMD_HELP,
+    ORPCLI_CMD_QUIT,
+    ORPCLI_CMD_CREATE,
+    ORPCLI_CMD_DELETE,
+    ORPCLI_CMD_ADD,
+    ORPCLI_CMD_PUSH,
+    ORPCLI_CMD_GET,
+    ORPCLI_CMD_EXAMPLE,
+    ORPCLI_CMD_REPLY,
+    ORPCLI_CMD_UNKNOWN
+};
+
+/* Extract and look up the first word in a command string
+ * Case insensitive, matching continues up to the minimum of incomming command length or command
+ * name, whichever is shorter
+ */
+static enum commandTypeE commandExtract(char **line)
+{
+    char *saveptr = NULL;
+    char *cmdStr  = strtok_r(*line, " ", &saveptr);
+    size_t cmdLen = strlen(cmdStr);
+
+    *line += cmdLen + 1;
+
+    if (!strncasecmp(cmdStr, "create", cmdLen))
+        return ORPCLI_CMD_CREATE;
+    if (!strncasecmp(cmdStr, "delete", cmdLen))
+        return ORPCLI_CMD_DELETE;
+    if (!strncasecmp(cmdStr, "add", cmdLen))
+        return ORPCLI_CMD_ADD;
+    if (!strncasecmp(cmdStr, "push", cmdLen))
+        return ORPCLI_CMD_PUSH;
+    if (!strncasecmp(cmdStr, "get", cmdLen))
+        return ORPCLI_CMD_GET;
+    if (!strncasecmp(cmdStr, "example", cmdLen))
+        return ORPCLI_CMD_EXAMPLE;
+    if (!strncasecmp(cmdStr, "reply", cmdLen))
+        return ORPCLI_CMD_REPLY;
+    if (!strncasecmp(cmdStr, "help", cmdLen))
+        return ORPCLI_CMD_HELP;
+    if (!strncasecmp(cmdStr, "quit", cmdLen))
+        return ORPCLI_CMD_QUIT;
+
+    printf("Unrecognized command: %s\n", cmdStr);
+    return ORPCLI_CMD_UNKNOWN;
+}
+
+// Parse a string into an argument array.  Parsing stops at argcMax
+static int string2Args(char *str, char *argv[], int argcMax)
+{
+    char *saveptr = NULL;
+    int argc = 0;
+
+    if (str && strlen(str))
+    {
+        // Stop parsing when the count (argc + 1) reaches the max requested
+        for (argv[argc] = strtok_r(str, " ", &saveptr);
+             argv[argc] && (++argc < argcMax);
+             argv[argc] = strtok_r(NULL, " ", &saveptr));
+    }
+    return argc;
+}
+
+// Check argument count
+static bool checkArgCount(int argc, int min, int max)
+{
+    if ((min < max) && (min <= argc && argc <= max))
+    {
+        return true;
+    }
+    else if ((min == max) && (min == argc))
+    {
+        return true;
+    }
+    else
+    {
+        printf("Invalid number of arguments %u\n", argc);
+    }
+    return false;
+}
+
+// Check that a path is non-null and non-zero length
+static bool checkPath(char *path)
+{
+    if (!path || !strlen(path))
+    {
+        printf("Invalid path argument\n");
+        return false;
+    }
+    return true;
+}
+
+// Convert string argument to data type enumeration
+static enum orp_IoDataType dataTypeRead(char *dtypeStr)
+{
+    if (!dtypeStr)
+    {
+        return ORP_IO_DATA_TYPE_UNDEF;
+    }
+    switch (tolower(dtypeStr[0]))
+    {
+        case 't': return ORP_IO_DATA_TYPE_TRIGGER;
+        case 'b': return ORP_IO_DATA_TYPE_BOOLEAN;
+        case 'n': return ORP_IO_DATA_TYPE_NUMERIC;
+        case 's': return ORP_IO_DATA_TYPE_STRING;
+        case 'j': return ORP_IO_DATA_TYPE_JSON;
+        default:
+            printf("Invalid data type: %s\n", dtypeStr);
+            return ORP_IO_DATA_TYPE_UNDEF;
+    }
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Individual command handling
+ */
+//--------------------------------------------------------------------------------------------------
+/* Create a resource:
+ * > create input|output|sensor  trig|bool|num|str|json <path> [<units>]
+ */
+static void commandCreate(char *args)
+{
+    char *argv[6];
+    int argc = 0;
+
+    argc = string2Args(args, argv, 6);
+    if (!checkArgCount(argc, 3, 4))
+    {
+        return;
+    }
+    enum orp_IoDataType dataType = dataTypeRead(argv[1]);
+    if (ORP_IO_DATA_TYPE_UNDEF == dataType)
+    {
+        return;
+    }
+    char *path = argv[2];
+    if (!checkPath(path))
+    {
+        return;
+    }
+    // Units (optional)
+    char *units = (argv[3] && strlen(argv[3])) ? argv[3] : "";
+    // input | output | sensor
+    switch (tolower(argv[0][0]))
+    {
+        case 'i': (void)orp_CreateResource(true, path, dataType, units); break;
+        case 'o': (void)orp_CreateResource(false, path, dataType, units); break;
+        case 's': (void)orp_CreateSensor(path, dataType, units); break;
+        default: printf("Invalid resource type %s\n", argv[0]); break;
+    }
+}
+
+/* Delete resource || sensor || handler:
+ * > delete resource|handler|sensor <path>'
+ */
+static void commandDelete(char *args)
+{
+    char *argv[6];
+    int argc = 0;
+
+    argc = string2Args(args, argv, 6);
+    if (!checkArgCount(argc, 2, 2))
+    {
+        return;
+    }
+    char *path = argv[1];
+    if (!checkPath(path))
+    {
+        return;
+    }
+    // resource | handler | sensor
+    switch (tolower(argv[0][0]))
+    {
+        case 'r': (void)orp_DeleteResource(path); break;
+        case 'h': (void)orp_RemovePushHandler(path); break;
+        case 's': (void)orp_DestroySensor(path); break;
+        default: printf("Unrecognized type: %s\n", argv[0]); break;
+    }
+}
+
+/* Add a push handler on a resource
+ * > add handler <path>
+ */
+static void commandAdd(char *args)
+{
+    char *argv[6];
+    int argc = 0;
+
+    argc = string2Args(args, argv, 6);
+    if (!checkArgCount(argc, 2, 2))
+    {
+        return;
+    }
+    char *path = argv[1];
+    if (!checkPath(path))
+    {
+        return;
+    }
+    if (tolower(argv[0][0]) != 'h')
+    {
+        printf("Unrecognized type: %s\n", argv[0]);
+        return;
+    }
+    (void)orp_AddPushHandler(path);
+}
+
+/* Push value to a resource
+ * > push trig|bool|num|str|json <path> <timestamp> [<data>] (note: if <timestamp> = 0, current timestamp will be used)
+ */
+static void commandPush(char *args)
+{
+    char *argv[6];
+    int argc = 0;
+    char *argsEnd = args + strlen(args);
+
+    /* !!! Only parse the first 3 args.  The fourth is data, which may contain
+     * spaces.  We deal with the data arg separately, below
+     */
+    argc = string2Args(args, argv, 3);
+    if (!checkArgCount(argc, 3, 3))
+    {
+        return;
+    }
+    // Point to the data string, if present
+    char *data = NULL;
+    argv[argc] = argv[argc - 1] + strlen(argv[argc - 1]) + 1;
+    if (argv[argc] < argsEnd)
+    {
+        data = argv[argc];
+    }
+
+    enum orp_IoDataType dataType = dataTypeRead(argv[0]);
+    if (ORP_IO_DATA_TYPE_UNDEF == dataType)
+    {
+        return;
+    }
+    char *path = argv[1];
+    if (!checkPath(path))
+    {
+        return;
+    }
+    double timestamp = 0.0;
+    if (1 != sscanf(argv[2], "%lf", &timestamp))
+    {
+        printf("Invalid timestamp %s\n", argv[2]);
+        return;
+    }
+    (void)orp_Push(path, dataType, timestamp, data);
+}
+
+/* Get the value from a resource
+ * > get <path>
+ */
+static void commandGet(char *args)
+{
+    char *argv[6];
+    int argc = 0;
+
+    argc = string2Args(args, argv, 6);
+    if (!checkArgCount(argc, 1, 1))
+    {
+        return;
+    }
+    char *path = argv[0];
+    if (!checkPath(path))
+    {
+        return;
+    }
+    (void)orp_Get(path);
+}
+
+/* Set JSON example
+ * > example json <path> [<data>]
+ */
+static void commandExample(char *args)
+{
+    char *argv[6];
+    int argc = 0;
+
+    argc = string2Args(args, argv, 6);
+    if (!checkArgCount(argc, 2, 3))
+    {
+        return;
+    }
+    enum orp_IoDataType dataType = dataTypeRead(argv[0]);
+    if (ORP_IO_DATA_TYPE_JSON != dataType)
+    {
+        return;
+    }
+    char *path = argv[1];
+    if (!checkPath(path))
+    {
+        return;
+    }
+    char *data = argv[2];
+    (void)orp_SetJsonExample(path, data);
+}
+
+/* Respond to a notification or unsolicited packet
+ * > reply resource| <status>
+ */
+static void commandRespond(char *args)
+{
+    char *argv[6];
+    int argc = 0;
+
+    argc = string2Args(args, argv, 6);
+    if (!checkArgCount(argc, 1, 2))
+    {
+        return;
+    }
+    unsigned int status = 0; // default to OK | Version 1
+    if (   (2 == argc)
+        && (1 != sscanf(argv[1], "%d", &status)))
+    {
+        printf("Invalid status %s\n", argv[1]);
+        return;
+    }
+    // handler | sensor | sync
+    enum orp_PacketType responseType;
+    if (!strncasecmp(argv[0], "handler", strlen(argv[0])))
+    {
+        responseType = ORP_RESP_HANDLER_CALL;
+    }
+    else if (!strncasecmp(argv[0], "sensor", strlen(argv[0])))
+    {
+        responseType = ORP_RESP_SENSOR_CALL;
+    }
+    else if (!strncasecmp(argv[0], "syn", strlen(argv[0])))
+    {
+        responseType = ORP_SYNC_ACK;
+    }
+    else if (!strncasecmp(argv[0], "synack", strlen(argv[0])))
+    {
+        responseType = ORP_SYNC_SYNACK;
+    }
+    else
+    {
+        printf("Unknown response type %s\n", argv[0]);
+        return;
+    }
+    (void)orp_Respond(responseType, status);
+}
+
+/* > help
+ */
+static void commandHelp(char *args)
+{
+    printf(helpStr);
+}
+
+bool commandDispatch(char *request)
+{
+    if (strlen(request) >= 1)
+    {
+        // The command (first argument) determines how parsing is done on the rest of the line
+        switch (commandExtract(&request))
+        {
+            case ORPCLI_CMD_CREATE:  commandCreate(request); break;
+            case ORPCLI_CMD_DELETE:  commandDelete(request); break;
+            case ORPCLI_CMD_ADD:     commandAdd(request); break;
+            case ORPCLI_CMD_PUSH:    commandPush(request); break;
+            case ORPCLI_CMD_GET:     commandGet(request); break;
+            case ORPCLI_CMD_EXAMPLE: commandExample(request); break;
+            case ORPCLI_CMD_REPLY:   commandRespond(request); break;
+            case ORPCLI_CMD_HELP:    commandHelp(request); break;
+            case ORPCLI_CMD_QUIT:    return false;
+            default:
+                break;
+        }
+    }
+    return true;
+}

--- a/clients/c/src/hdlc.c
+++ b/clients/c/src/hdlc.c
@@ -1,0 +1,421 @@
+/**
+ * @file:    hdlc.h
+ *
+ * Purpose:  Simplified Asynchronous HDLC utilities
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ * Partial HDLC implementation
+ * - Includes framing, escaping, and 16-bit CRC-CCITT
+ * - Does not include Address or control fields, or ACK/NACK
+ *
+ * Usage: see hdlc.h
+ *
+ */
+
+#include "hdlc.h"
+#include "legato.h"
+#include <string.h>
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Internal Definitions
+ */
+//--------------------------------------------------------------------------------------------------
+/* Async HDLC achieves data transparency at the byte level by using two
+ * special values. The first is a flag value which begins and ends every
+ * packet: */
+#define  HDLC_FRAME_OCTET      0x7E
+
+/* The flag value might appear in the data.  If it does, it is sent as a
+ * two-byte sequence consisting of a special escape value followed by the
+ * flag value XORed with 0x20.  This gives a special meaning to the escape
+ * character, so if it appears in the data it is itself escaped in the same
+ * way. */
+#define  HDLC_ESC_OCTET        0x7D
+#define  HDLC_ESC_MASK         0x20
+
+/* Indicies for the temporary CRC buffer.  The CRC is received LSB first, so the LSB is the
+ * older of the two bytes:
+ *
+ *   <data_0>...<data_N><CRC_LSB><CRC_MSB>
+ *   -------------------------------------> time
+ */
+#define  HDLC_FRAM_CRC_LSB     0
+#define  HDLC_FRAM_CRC_MSB     1
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * States used when processing simplified HDLC framing protocol
+ */
+//--------------------------------------------------------------------------------------------------
+enum hdlc_state
+{
+    HDLC_INIT = 0,             /* State intialized, no calls yet                    */
+
+    UNPACK_SOF_SEARCH,         /* State machine is hunting for the start of a frame */
+    UNPACK_SOF_FOUND,          /* Frame detected                                    */
+    UNPACK_DATA,               /* Receiving data                                    */
+    UNPACK_ESCAPED,            /* Escape detected, getting the next character       */
+
+    PACK_START,                /* Sending the opening frame of a packet             */
+    PACK_DATA,                 /* Sending out data characters, no escape            */
+    PACK_ESCAPED               /* Escape character was sent                         */
+};
+
+// This is to be moved to crc.[ch]
+#define CRC_CRC16_CCITT_INIT 0xFFFF
+#define CRC_POLY_CCITT 0x1021
+static bool             crc_tabccitt_init       = false;
+static uint16_t         crc_tabccitt[256];
+static void init_crcccitt_tab( void ) {
+
+	uint16_t i;
+	uint16_t j;
+	uint16_t crc;
+	uint16_t c;
+
+	for (i=0; i<256; i++) {
+
+		crc = 0;
+		c   = i << 8;
+
+		for (j=0; j<8; j++) {
+
+			if ( (crc ^ c) & 0x8000 ) crc = ( crc << 1 ) ^ CRC_POLY_CCITT;
+			else                      crc =   crc << 1;
+
+			c = c << 1;
+		}
+
+		crc_tabccitt[i] = crc;
+	}
+
+	crc_tabccitt_init = true;
+
+}  /* init_crcccitt_tab */
+
+uint16_t _crc_ccitt_update( uint16_t crc, uint8_t c ) {
+
+	if ( ! crc_tabccitt_init ) init_crcccitt_tab();
+
+	return (crc << 8) ^ crc_tabccitt[ ((crc >> 8) ^ (uint16_t) c) & 0x00FF ];
+
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Initialize HDLC context
+ */
+//--------------------------------------------------------------------------------------------------
+void hdlc_Init
+(
+    hdlc_context_t *hdlc
+)
+//--------------------------------------------------------------------------------------------------
+{
+    LE_ASSERT(hdlc);
+    memset(hdlc, 0, sizeof(hdlc_context_t));
+    hdlc->state = HDLC_INIT;
+    hdlc->crc = CRC_CRC16_CCITT_INIT;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Unpack an HDLC frame
+ */
+//--------------------------------------------------------------------------------------------------
+ssize_t hdlc_Unpack
+(
+    hdlc_context_t *hdlc,
+    uint8_t        *dest,
+    size_t          destlen,
+    uint8_t        *src,
+    size_t         *srclen
+)
+//--------------------------------------------------------------------------------------------------
+{
+    int      dst_idx = 0;               // recieved length of the packet
+    int      src_idx = 0;               // recieved length of the packet
+
+    if (hdlc)
+    {
+        while ((src_idx < (int)*srclen) && (dst_idx < (int)destlen))
+        {
+            uint8_t data = src[src_idx];
+
+            switch (hdlc->state)
+            {
+                case HDLC_INIT:
+                    hdlc->state = UNPACK_SOF_SEARCH;
+                    hdlc->crc = CRC_CRC16_CCITT_INIT;
+                    hdlc->count = 0;
+                    /* fall through */
+
+                case UNPACK_SOF_SEARCH:
+                    if (data == HDLC_FRAME_OCTET)
+                    {
+                        hdlc->state = UNPACK_SOF_FOUND;
+                    }
+                    /* discard anything else until SOF found */
+                    break;
+
+                case UNPACK_SOF_FOUND:
+                    switch (data)
+                    {
+                        /* contiguous frame flag - no change */
+                        case HDLC_FRAME_OCTET:
+                            break;
+
+                        case HDLC_ESC_OCTET:
+                            hdlc->state = UNPACK_ESCAPED;
+                            break;
+
+                        default:
+                            hdlc->state = UNPACK_DATA;
+                            break;
+                    }
+                    break;
+
+                case UNPACK_DATA:
+                    switch (data)
+                    {
+                        /* Frame Boundary: Unpacking complete. Compare the calculated CRC with
+                         * the CRC in the frame
+                         */
+                        case HDLC_FRAME_OCTET:
+                        {
+                            uint16_t sndrcrc = ((uint16_t)(hdlc->crcbuf[HDLC_FRAM_CRC_MSB]) << 8) + hdlc->crcbuf[HDLC_FRAM_CRC_LSB];
+                            if (hdlc->crc != sndrcrc)
+                            {
+                                LE_INFO("CRC Mismatch: calculated %04X, received %04X", hdlc->crc, sndrcrc);
+                                dst_idx = HDLC_ERROR_CRC;
+                            }
+                            hdlc->state = HDLC_INIT;
+                            break;
+                        }
+
+                        case HDLC_ESC_OCTET:
+                            hdlc->state = UNPACK_ESCAPED;
+                            break;
+
+                        // Regular data
+                        default:
+                            break;
+                    }
+                    break;
+
+                case UNPACK_ESCAPED:
+                    switch (data)
+                    {
+                        /* Errors:  Indicate error and reset state
+                         * - Duplicate escape
+                         * - Frame boundary while escaped
+                         */
+                        case HDLC_ESC_OCTET:
+                        case HDLC_FRAME_OCTET:
+                            LE_ERROR("Framing error");
+                            dst_idx = HDLC_ERROR_FRAME;
+                            hdlc->state = HDLC_INIT;
+                            break;
+
+                        default:
+                            data ^= HDLC_ESC_MASK;
+                            hdlc->state = UNPACK_DATA;
+                            break;
+                    }
+                    break;
+
+                default:
+                    LE_FATAL("Invalid state %d", hdlc->state);
+                    break;
+            }
+
+            /* If unpacking, copy data to output buffer and update CRC */
+            if (UNPACK_DATA == hdlc->state)
+            {
+                /* running crc calculation on the unpacked data
+                 * if the current length of data unpacked is less than 2 bytes, it may actually be
+                 * the crc itself.  Therefore, buffer the two most recent bytes until the end of
+                 * frame occurs
+                 */
+                if (hdlc->count > 1)
+                {
+                    dest[dst_idx] = hdlc->crcbuf[HDLC_FRAM_CRC_MSB];
+                    hdlc->crc = _crc_ccitt_update(hdlc->crc, dest[dst_idx]);
+                    dst_idx++;
+                }
+                hdlc->crcbuf[HDLC_FRAM_CRC_MSB] = hdlc->crcbuf[HDLC_FRAM_CRC_LSB];
+                hdlc->crcbuf[HDLC_FRAM_CRC_LSB] = data;
+                hdlc->count++;
+            }
+
+            src_idx++;
+
+            if (HDLC_INIT == hdlc->state)
+            {
+                /* return to the caller */
+                break;
+            }
+        }
+    }
+
+    *srclen = src_idx;
+
+     return dst_idx;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Check whether HDLC unpacking is complete
+ */
+//--------------------------------------------------------------------------------------------------
+bool hdlc_UnpackDone
+(
+    hdlc_context_t *hdlc
+)
+//--------------------------------------------------------------------------------------------------
+{
+    if (hdlc && (HDLC_INIT == hdlc->state))
+    {
+        return true;
+    }
+    return false;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Pack an HDLC frame
+ */
+//--------------------------------------------------------------------------------------------------
+ssize_t hdlc_Pack
+(
+    hdlc_context_t *hdlc,
+    uint8_t        *dest,
+    size_t          destlen,
+    uint8_t        *src,
+    size_t         *srclen
+)
+//--------------------------------------------------------------------------------------------------
+{
+    int src_idx = 0;
+    int dst_idx = -1;
+
+
+    if (hdlc)
+    {
+        /* Newly initialized context - move to first state for packing */
+        if (HDLC_INIT == hdlc->state)
+        {
+            hdlc->state = PACK_START;
+        }
+
+        for (dst_idx = 0;
+             (src_idx < *srclen) && (dst_idx < destlen);
+             dst_idx++)
+        {
+            switch (hdlc->state)
+            {
+                case PACK_START:
+                    dest[dst_idx] = HDLC_FRAME_OCTET;
+                    hdlc->state = PACK_DATA;
+                    break;
+
+                case PACK_DATA:
+                    hdlc->crc = _crc_ccitt_update(hdlc->crc, src[src_idx]);
+                    if ((src[src_idx] == HDLC_FRAME_OCTET) || (src[src_idx] == HDLC_ESC_OCTET))
+                    {
+                        dest[dst_idx] = HDLC_ESC_OCTET;
+                        hdlc->state = PACK_ESCAPED;
+                    }
+                    else
+                    {
+                        dest[dst_idx] = src[src_idx++];
+                    }
+                    break;
+
+                case PACK_ESCAPED:
+                    dest[dst_idx] = (src[src_idx++] ^ HDLC_ESC_MASK);
+                    hdlc->state = PACK_DATA;
+                    break;
+
+                default:
+                    LE_FATAL("Invalid state %d", hdlc->state);
+                    break;
+            }
+        }
+    }
+
+    *srclen = src_idx;
+
+    return dst_idx;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Complete HDLC packing
+ */
+//--------------------------------------------------------------------------------------------------
+ssize_t hdlc_PackFinalize
+(
+    hdlc_context_t *hdlc,
+    uint8_t        *dest,
+    size_t          destlen
+)
+//--------------------------------------------------------------------------------------------------
+{
+    ssize_t count = -1;
+
+
+    // calculate crc and use hdlc_Pack() to add it to the end
+    if (hdlc)
+    {
+        size_t crcLen = sizeof(hdlc->crc);
+        hdlc->crcbuf[0] = hdlc->crc >> 8;
+        hdlc->crcbuf[1] = hdlc->crc & 0x00FF;
+
+        count = hdlc_Pack(hdlc, dest, destlen, hdlc->crcbuf, &crcLen);
+
+        destlen -= count;
+
+        if (destlen)
+        {
+            dest[count++] = HDLC_FRAME_OCTET;
+        }
+        else
+        {
+            LE_ERROR("Insufficient space");
+            count = -1;
+        }
+    }
+    return count;
+}

--- a/clients/c/src/main.c
+++ b/clients/c/src/main.c
@@ -1,0 +1,260 @@
+/**
+ * @file:    main.c
+ *
+ * Purpose:  Command-line utility to exercise Octave Resource Protocol example
+ * client code
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ * This command-line utility may be used to test and demonstrate the way in
+ * which a client (asset) uses the Octave Resource Protocol.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <errno.h>
+#include <string.h>
+#include <termios.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <poll.h>
+#include "orpClient.h"
+
+
+// Individual commands kept in command.c
+extern bool commandDispatch(char *request);
+
+// String lengths for some arguments
+#define DEV_STR_LEN_MAX   128
+#define BAUD_STR_LEN_MAX   32
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Usage
+ */
+//--------------------------------------------------------------------------------------------------
+const char usageStr[] =
+"Usage:\n\
+\tOctave Resource Protocol Client Utility\n\
+\tusage: orp [-h] -d DEV [-b BAUD]\n\
+\tWhere:\n\
+\t  DEV is the serial port (e.g. /dev/ttyUSB0)\n\
+\t  BAUD is the baudrate (example 115200, default value is 9600)\n\
+";
+
+void usage(void)
+{
+   printf(usageStr);
+}
+
+
+static char devStr[DEV_STR_LEN_MAX]   = {'\0'};
+static char baudStr[BAUD_STR_LEN_MAX] = {'\0'};
+static struct pollfd fds[2];
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Handle stdin and serial port data from a single thread
+ */
+//--------------------------------------------------------------------------------------------------
+void processIO(void)
+{
+    /* Unfortunately, the USB-to-Serial converter will fail to send the first packet after a
+     * period of inactivity (USB suspend).  Rather than changing the USB behavior, we just
+     * keep sending a preamble character to keep the bus from suspending.  Anything less than
+     * 5 seconds seems to work
+     */
+    int timeout_msecs = 3000;
+
+    fds[0].fd = 0; //stdin;
+    fds[0].events = POLLIN | POLLHUP;
+    fds[1].events = POLLIN | POLLHUP;
+
+    printf("\norp > ");
+    fflush(stdout);
+    for (bool done = false; !done; )
+    {
+        if (poll(fds, 2, timeout_msecs) > 0)
+        {
+            if (fds[0].revents & POLLIN)
+            {
+                char *line = NULL;
+                size_t len = 0;
+
+                len = getline(&line, &len, stdin);
+                if (line && len > 0)
+                {
+                    if ('\n' == line[len - 1])
+                        line[len - 1] = '\0';
+                    bool keepGoing = commandDispatch(line);
+                    free(line);
+                    if (!keepGoing)
+                    {
+                        printf("Exiting\n");
+                        break;
+                    }
+                }
+            }
+            if (fds[1].revents & POLLIN)
+            {
+                orp_ClientReceive();
+            }
+            if (fds[1].revents & POLLHUP)
+            {
+                printf("Received POLLHUP from %s. Exiting\n", devStr);
+                break;
+            }
+            printf("\norp > ");
+            fflush(stdout);
+        }
+        // send preamble byte to keep USB awake
+        (void)write(fds[1].fd, "~", 1);
+    }
+}
+
+speed_t baudGet(char *baudStr)
+{
+    speed_t baud = B0;
+
+    if (0 == strcmp("115200", baudStr))
+        baud = B115200;
+    else if (0 == strcmp("9600", baudStr))
+        baud = B9600;
+    else if (0 == strcmp("38400", baudStr))
+        baud = B38400;
+    else if (0 == strcmp("57600", baudStr))
+        baud = B57600;
+
+    return baud;
+}
+
+int configureSerial(char *devStr, char *baudStr)
+{
+    int fd = -1;
+    speed_t baud;
+    struct termios settings;
+
+    baud = baudGet(baudStr);
+    if (B0 == baud)
+    {
+        printf("Invalid baud rate %s\n", baudStr);
+    }
+    else
+    {
+        fd = open(devStr, O_RDWR | O_SYNC /* O_NONBLOCK */);
+        if (fd < 0)
+        {
+            printf("Failed to open %s.  Error %s\n", devStr, strerror(errno));
+        }
+        else
+        {
+            tcgetattr(fd, &settings);
+            cfmakeraw(&settings);
+            cfsetospeed(&settings, baud);
+
+            // 8 bits, No parity, 1 stop bit
+            settings.c_cflag &= ~CSIZE;
+            settings.c_cflag |= CS8;
+            settings.c_cflag &= ~PARENB;
+            settings.c_cflag &= ~CSTOPB;
+
+            tcsetattr(fd, TCSANOW, &settings);
+            tcflush(fd, TCOFLUSH);
+        }
+    }
+    return fd;
+}
+
+int main(int argc, char **argv)
+{
+    int c;
+    int i;
+    bool status = false;
+
+    opterr = 0;
+
+    while ((c = getopt(argc, argv, "b:d:h:v")) != -1)
+    {
+        switch (c)
+        {
+            case 'b':  // baud rate
+                strncpy(baudStr, optarg, sizeof(baudStr));
+                break;
+
+            case 'd':  // serial device
+                strncpy(devStr, optarg, sizeof(devStr));
+                break;
+
+            case '?':
+                if (optopt == 'b' || optopt == 'd')
+                {
+                    fprintf (stderr, "Option -%c requires an argument.\n", optopt);
+                    status = true;
+                }
+                else
+                {
+                    fprintf (stderr, "Unknown option character `\\x%x'.\n", optopt);
+                }
+                usage();
+                goto done;
+
+            case 'h':  // help
+                status = true;
+                usage();
+                goto done;
+
+            default:
+                usage();
+                goto done;
+        }
+    }
+
+    printf("ORP Serial Client - \"h\" for help, \"q\" to exit\n");
+    printf("using device: %s, Baud: %s\n", devStr, baudStr);
+
+    fds[1].fd = configureSerial(devStr, baudStr);
+    if (fds[1].fd < 0)
+    {
+        goto done;
+    }
+    if (!orp_ClientInit(fds[1].fd))
+    {
+        goto done;
+    }
+
+    processIO();
+
+done:
+    if (fds[1].fd > 0)
+    {
+        close(fds[1].fd);
+    }
+
+    exit(status ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/clients/c/src/orpClient.c
+++ b/clients/c/src/orpClient.c
@@ -1,0 +1,631 @@
+/**
+ * @file:    orpClient.c
+ *
+ * Purpose:  Example client functions for the Octave Resource Protocol
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ */
+
+#include <unistd.h>
+#include <string.h>
+#include "orpClient.h"
+#include "orpUtils.h"
+#include "hdlc.h"
+#include "legato.h"
+
+
+/* Buffers:
+ *
+ * The hdlc functions require non-overlapping input and output buffers so we must keep
+ * at least one for each of: outbound encoded, outbound framed, inbound framed, and
+ * inbound decoded.
+ *
+ * Sizing:
+ *
+ * Unframed packets are sized by the data length, plus a fixed component.  The fixed part
+ * is defined in orpProtocol.h: ORP_PROTOCOL_LEN_NO_DATA_MAX
+ * The data length may be set according to the client requirements but this length must
+ * not exceed the maximum data size supported by the Datahub: IO_MAX_STRING_VALUE_LEN
+ *
+ * HDLC framed packets require space for the framing and crc bytes: HDLC_OVERHEAD_BYTES_COUNT,
+ * plus the packet contents with some number of escape bytes.  The upper limit on the
+ * escaped contents is: 2 * <max data length>.  If buffer size is a concern, a smaller
+ * increase over the max data length is usually enough for real-world data - e.g. 10%
+ *
+ * This example is written to handle only one outbound and one inbound message at a time,
+ * using static buffers
+ */
+
+// Max data length.  Setting equal to the Datahub max here
+#define ORP_PACKET_DATA_SIZE_MAX    IO_MAX_STRING_VALUE_LEN
+
+// Max size of an unframed request/response packet; including protocol fields:
+#define ORP_PACKET_SIZE_MAX         (  ORP_PROTOCOL_LEN_NO_DATA_MAX \
+                                     + ORP_PACKET_DATA_SIZE_MAX)
+
+/* Max frame size.  Using a factor of 2 here in order to support stress-testing with all
+ * needing to be escaped.  Normally, this isn't necessary
+ */
+#define ORP_HDLC_FRAME_SIZE_MAX     ((ORP_PACKET_SIZE_MAX * 2) + HDLC_OVERHEAD_BYTES_COUNT)
+
+static uint8_t rxFrameBuf[ORP_HDLC_FRAME_SIZE_MAX];
+static uint8_t rxPacketBuf[ORP_PACKET_SIZE_MAX];
+
+static uint8_t txFrameBuf[ORP_HDLC_FRAME_SIZE_MAX];
+static uint8_t txPacketBuf[ORP_PACKET_SIZE_MAX];
+
+// ORP encoder/decoder structure, initialized via orp_ProtocolClientInit()
+static struct orp_ProtocolCodec codec;
+
+// File descriptor on which to send and receive frames, passed in by caller
+static int fd = -1;
+
+// HDLC context
+static hdlc_context_t rxHdlcContext;
+
+// Count of the number of frames transmitted so far.  This will roll-over
+static uint16_t sequenceNum = 0;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Initialize local variables and state
+ */
+//--------------------------------------------------------------------------------------------------
+bool orp_ClientInit
+(
+    int fileDescriptor
+)
+{
+    if (fileDescriptor < 0)
+    {
+        printf("Invalid file descriptor\n");
+        return false;
+    }
+    if (!orp_ProtocolClientInit(ORP_PROTOCOL_V1, &codec))
+    {
+        printf("Failed to initialize protocol\n");
+        return false;
+    }
+    printf("Protocol codec initialized\n");
+    fd = fileDescriptor;
+    sequenceNum = 0;
+    hdlc_Init(&rxHdlcContext);
+
+    return true;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode a message structure into a packet buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_Encode
+(
+    uint8_t            *packetBuffer,
+    size_t             *packetBufferLen,
+    struct orp_Message *message
+)
+{
+    return codec.encode(packetBuffer, packetBufferLen, message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Decode a packet buffer into a message structure
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_Decode
+(
+    uint8_t            *packetBuffer,
+    size_t              packetBufferLen,
+    struct orp_Message *message
+)
+{
+    return codec.decode(packetBuffer, packetBufferLen, message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Frame a packet as HDLC
+ *
+ * @note:  The hdlc_Pack routine allows data to be streamed through it, to allow the use of
+ * buffers which are smaller than the frame size
+ */
+//--------------------------------------------------------------------------------------------------
+static ssize_t orp_Enframe
+(
+    uint8_t *frameBuf,
+    size_t   frameBufSize,
+    uint8_t *packet,
+    size_t   packetLen
+)
+{
+    hdlc_context_t context;
+    ssize_t frameLen;
+    size_t count = packetLen;
+
+
+    LE_ASSERT(frameBuf && packet);
+
+    if (frameBufSize < packetLen + HDLC_OVERHEAD_BYTES_COUNT)
+    {
+        printf("Frame buffer too small (%zu bytes)\n", frameBufSize);
+        goto err;
+    }
+
+    // Initialize the framing context
+    hdlc_Init(&context);
+    memset(frameBuf, 0, frameBufSize);
+
+    // Frame the packet
+    frameLen = hdlc_Pack(&context, frameBuf, frameBufSize, packet, &count);
+
+    // Check that all of the packet was loaded into the frame buffer
+    if (count < packetLen)
+    {
+        printf("Failed to frame packet (loaded: %zu / %zu)\n", count, packetLen);
+        goto err;
+    }
+    // Check that there is enough room remaining in the buffer to finalize the frame
+    // (leading 0x7E already prepended)
+    if (frameBufSize - frameLen < (HDLC_OVERHEAD_BYTES_COUNT - 1))
+    {
+        printf("Frame buffer too small to finalize (used: %zu / %zu)\n", frameLen, frameBufSize);
+        goto err;
+    }
+    count = hdlc_PackFinalize(&context, frameBuf + frameLen, frameBufSize - frameLen);
+    if (count < 0)
+    {
+        printf("Frame buffer too small to finalize (%zu bytes)\n", frameBufSize);
+        goto err;
+    }
+    frameLen += count;
+
+    return frameLen;
+
+err:
+    return -1;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Simple transmit routine
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_Transmit
+(
+    uint8_t *data,
+    size_t  dataLen
+)
+{
+    int rc = -1;
+
+    if (dataLen)
+    {
+        rc = write(fd, data, dataLen);
+    }
+
+    return rc > 0 ? true : false;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Convert a message structure to a framed ORP packet and send
+ */
+//--------------------------------------------------------------------------------------------------
+static le_result_t orp_ClientMessageSend
+(
+    struct orp_Message *message
+)
+{
+    uint8_t *packetBuffer = txPacketBuf;
+    size_t   packetBufferLen = sizeof(txPacketBuf);
+    uint8_t *frameBuffer = txFrameBuf;
+    size_t   frameBufferSize = sizeof(txFrameBuf);
+
+
+    // Set sequence number
+    message->sequenceNum = sequenceNum;
+
+    // Encode the packet
+    if (!orp_Encode(packetBuffer, &packetBufferLen, message))
+    {
+        printf("Failed to encode request\n");
+        goto err;
+    }
+
+    // Frame packet
+    ssize_t frameLen = orp_Enframe(frameBuffer, frameBufferSize, packetBuffer, packetBufferLen);
+    if (frameLen < 0)
+    {
+        printf("Failed to frame packet %zd\n", frameLen);
+        goto err;
+    }
+    // Send the request
+    printf("Sending:");
+    printf(" '%c%c%c%01u%01u%s', (%zu bytes)\n",
+           frameBuffer[0], frameBuffer[1], frameBuffer[2], frameBuffer[3], frameBuffer[4], &frameBuffer[5], frameLen);
+    orp_MessagePrint(message);
+
+    if (!orp_Transmit(frameBuffer, frameLen))
+    {
+        printf("Failed to send request\n");
+        goto err;
+    }
+
+    sequenceNum++;
+    return LE_OK;
+
+err:
+    return LE_FAULT;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Handle an incomimg message
+ */
+//--------------------------------------------------------------------------------------------------
+static void orp_Dispatch
+(
+    struct orp_Message *message
+)
+{
+    // nothing implemented yet
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Deframe and decode packets
+ */
+//--------------------------------------------------------------------------------------------------
+static size_t orp_Deframe
+(
+    uint8_t *frameBuf,
+    size_t   frameLen
+)
+{
+    static size_t rxPacketLen = 0;
+    size_t consumed = 0;
+
+
+    do
+    {
+        /* hdlc_Unpack returns a negative value on error.  This will happen if bytes are missed
+         * or are corrupt.  When this occurs, decrement the count of received hdlc bytes as usual
+         * Reset the deframed buffer as the frame is not useable
+         */
+        size_t count = frameLen;
+        ssize_t hdlcResult = hdlc_Unpack(&rxHdlcContext,
+                                         rxPacketBuf + rxPacketLen,
+                                         sizeof(rxPacketBuf) - rxPacketLen,
+                                         frameBuf, &count);
+        frameLen -= count;
+        frameBuf += count;
+        consumed += count;
+        if (hdlcResult < 0)
+        {
+            printf("Failed to unpack data %zd\n", hdlcResult);
+            goto err;
+        }
+
+        // Increment the deframed packet length and check for overflow
+        rxPacketLen += hdlcResult;
+        if (rxPacketLen > sizeof(rxPacketBuf))
+        {
+            printf("Packet length exceeded %zd\n", rxPacketLen);
+            goto err;
+        }
+
+        // If a complete frame was NOT unpacked, there is nothing left to do
+        if (!hdlc_UnpackDone(&rxHdlcContext))
+        {
+            break;
+        }
+
+        // Decode and process the received packet
+        struct orp_Message message;
+        bool result = orp_Decode(rxPacketBuf, rxPacketLen, &message);
+        if (!result)
+        {
+            goto err;
+        }
+
+        printf("\nReceived:");
+        printf(" '%c%c%01X%01X%s', (%zu bytes)",
+               rxPacketBuf[0], rxPacketBuf[1], rxPacketBuf[2], rxPacketBuf[3], &rxPacketBuf[4], rxPacketLen);
+        printf("\n");
+        orp_MessagePrint(&message);
+
+        orp_Dispatch(&message);
+
+        // Reset hdlc context and packet length for the next frame
+        hdlc_Init(&rxHdlcContext);
+        rxPacketLen = 0;
+
+    } while (frameLen > 0);
+
+    return consumed;
+
+err:
+    hdlc_Init(&rxHdlcContext);
+    rxPacketLen = 0;
+    return consumed;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reads bytes from the file descriptor, deframes them, and decodes packets. This routine can be
+ * called on any number of received bytes - i.e. it is not necessary to wait for a frame boundary.
+ * When a full frame has been received, the resulting packet is decoded.
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_ClientReceive
+(
+    void
+)
+{
+    static size_t rxFrameLen = 0;
+    ssize_t count;
+
+    count = read(fd, rxFrameBuf + rxFrameLen, sizeof(rxFrameBuf) - rxFrameLen);
+    if (count < 0)
+    {
+        printf("Failed to receive\n");
+    }
+    else
+    {
+        rxFrameLen += count;
+        count = orp_Deframe(rxFrameBuf, rxFrameLen);
+        rxFrameLen -= count;
+        // Shift remaining bytes in the Frame Buffer to the beginning, for processing next time
+        if (rxFrameLen > 0)
+        {
+            memmove(rxFrameBuf, rxFrameBuf + count, rxFrameLen);
+        }
+    }
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create a resource in the Data Hub
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_CreateResource
+(
+    bool isInput,
+    const char *path,
+    enum orp_IoDataType dataType,
+    const char *units
+)
+{
+    struct orp_Message message;
+    enum orp_PacketType rqstType = isInput ? ORP_RQST_INPUT_CREATE : ORP_RQST_OUTPUT_CREATE;
+
+    // Copy arguments to the outbound message template.  Buffers will be copied when encoding.
+    orp_MessageInit(&message, rqstType, 0);
+    message.path = path;           // Resource path
+    message.dataType = dataType;   // Resource data type
+    message.unit = units;          // Resource units (optional)
+    return orp_ClientMessageSend(&message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Delete a resource
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_DeleteResource
+(
+    const char *path
+)
+{
+    struct orp_Message message;
+
+    orp_MessageInit(&message, ORP_RQST_DELETE, 0);
+    message.path = path;
+    return orp_ClientMessageSend(&message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Register for notifications on a resource
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_AddPushHandler
+(
+    const char *path
+)
+{
+    struct orp_Message message;
+
+    orp_MessageInit(&message, ORP_RQST_HANDLER_ADD, 0);
+    message.path = path;
+    return orp_ClientMessageSend(&message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Deregister for notifications on a resource
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_RemovePushHandler
+(
+    const char *path
+)
+{
+    struct orp_Message message;
+
+    orp_MessageInit(&message, ORP_RQST_HANDLER_REM, 0);
+    message.path = path;
+    return orp_ClientMessageSend(&message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a string-encoded data sample
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_Push
+(
+    const char *path,
+    enum orp_IoDataType dataType,
+    double timestampSec,
+    const char *value
+)
+{
+    struct orp_Message message;
+
+    orp_MessageInit(&message, ORP_RQST_PUSH, 0);
+    message.dataType = dataType;
+    message.path = path;
+    message.timestamp = timestampSec;
+    if (value)
+    {
+        message.data = (void *)value;
+        message.dataLen = strlen(value);
+    }
+    return orp_ClientMessageSend(&message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Request a string-encoded data sample
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_Get
+(
+    const char *path
+)
+{
+    struct orp_Message message;
+
+    orp_MessageInit(&message, ORP_RQST_GET, 0);
+    message.path = path;
+    return orp_ClientMessageSend(&message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the example value for a JSON-type Input resource
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_SetJsonExample
+(
+    const char *path,
+    const char *example
+)
+{
+    struct orp_Message message;
+
+    orp_MessageInit(&message, ORP_RQST_EXAMPLE_SET, 0);
+    message.path = path;
+    message.dataType = ORP_IO_DATA_TYPE_JSON;
+    message.data = (void *)example;
+    return orp_ClientMessageSend(&message);
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create a sensor in the Data Hub
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_CreateSensor
+(
+    const char *path,
+    enum orp_IoDataType dataType,
+    const char *units
+)
+{
+    struct orp_Message message;
+
+    orp_MessageInit(&message, ORP_RQST_SENSOR_CREATE, 0);
+    message.path = path;
+    message.dataType = dataType;
+    message.unit = units;
+    return orp_ClientMessageSend(&message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Delete a sensor
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_DestroySensor
+(
+    const char *path
+)
+{
+    struct orp_Message message;
+
+    orp_MessageInit(&message, ORP_RQST_SENSOR_REMOVE, 0);
+    message.path = path;
+    return orp_ClientMessageSend(&message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Respond to a notification or unsolicited packet
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_Respond
+(
+    enum orp_PacketType type,
+    int status
+)
+{
+    struct orp_Message message;
+
+    switch (type)
+    {
+        case ORP_RESP_HANDLER_CALL: break;
+        case ORP_RESP_SENSOR_CALL: break;
+        case ORP_SYNC_SYNACK: break;
+        case ORP_SYNC_ACK: break;
+        default: return LE_BAD_PARAMETER;
+    }
+    orp_MessageInit(&message, type, status);
+    return orp_ClientMessageSend(&message);
+}

--- a/clients/c/src/orpProtocol.c
+++ b/clients/c/src/orpProtocol.c
@@ -1,0 +1,1084 @@
+/**
+ * @file:    orpProtocol.c
+ *
+ * Purpose:  Octave Resource Protocol packet encoding and decoding functions
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ * Refer to the Octave Resource Protocol description here:
+ * https://docs.octave.dev/docs/octave-resource-protocol
+ *
+ */
+
+#include "orpProtocol.h"
+#include "legato.h"
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <ctype.h>
+
+
+#ifndef MIN
+#    define MIN(a,b) (((a) < (b)) ? (a) : (b))
+#endif
+
+/* Request/response bytes are chosen to be human-readable (ASCII)
+ *
+ * Strings must be null terminated.  These also act as the separator,
+ * since any other character could appear as data
+ *
+ * Time represented as ASCII hex chars in ms:
+ *
+ * For sending via ASCII terminal, <CR> used to indicate "send", so best not to use
+ * <CR> as a separator
+ *
+ * Fixed length fields:
+ *
+ *   pack_type[1] :
+ *   data_type[1] :
+ *   pad[2]       : future - to support multi-packet transactions
+ *
+ * Variable length fields:
+ *
+ *   path:  P<path chars><separator>     E.g:  P/app/remote/sensor/value<separator>
+ *   time:  T<decimal chars><separator>  E.g:  T1541112861.982<separator>
+ *   unit:  U<unit chars><separator>     E.g:  UmV<separator>
+ *   data:  D<data chars>                E.g:  D{ \"value\" : 123, \"timestamp\" : 1541112861 }
+ *
+ *   Note: Data may contain the terminator so it must therefore be last
+ */
+// <source id> <dest id> <trans number> <type> <contents>
+
+#define  ORP_PKT_RQST_INPUT_CREATE   'I'   // type[1] d_type[1] pad[2] path[] units[]
+#define  ORP_PKT_RESP_INPUT_CREATE   'i'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_RQST_OUTPUT_CREATE  'O'   // type[1] d_type[1] pad[2] path[] units[]
+#define  ORP_PKT_RESP_OUTPUT_CREATE  'o'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_RQST_DELETE         'D'   // type[1] pad[1]    pad[2] path[]
+#define  ORP_PKT_RESP_DELETE         'd'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_RQST_HANDLER_ADD    'H'   // type[1] pad[1]    pad[2] path[]
+#define  ORP_PKT_RESP_HANDLER_ADD    'h'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_RQST_HANDLER_REMOVE 'K'   // type[1] pad[1]    pad[2] path[]
+#define  ORP_PKT_RESP_HANDLER_REMOVE 'k'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_RQST_PUSH           'P'   // type[1] d_type[1] pad[2] time[] path[] data[]
+#define  ORP_PKT_RESP_PUSH           'p'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_RQST_GET            'G'   // type[1] pad[1]    pad[2] path[]
+#define  ORP_PKT_RESP_GET            'g'   // type[1] status[1] pad[2] time[] data[]
+
+#define  ORP_PKT_RQST_EXAMPLE_SET    'E'   // type[1] d_type[1] pad[2] path[] data[]
+#define  ORP_PKT_RESP_EXAMPLE_SET    'e'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_RQST_SENSOR_CREATE  'S'   // type[1] d_type[1] pad[2] path[] units[]
+#define  ORP_PKT_RESP_SENSOR_CREATE  's'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_RQST_SENSOR_REMOVE  'R'   // type[1] pad[1]    pad[2] path[]
+#define  ORP_PKT_RESP_SENSOR_REMOVE  'r'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_NTFY_HANDLER_CALL   'c'   // type[1] d_type[1] pad[2] time[] path[] data[]
+#define  ORP_PKT_RESP_HANDLER_CALL   'C'   // type[1] status[1] pad[2]
+
+#define  ORP_PKT_NTFY_SENSOR_CALL    'b'   // type[1] pad[1]    pad[2] path[]
+#define  ORP_PKT_RESP_SENSOR_CALL    'B'   // type[1] status[1] pad[2]
+
+// Version 2
+#define  ORP_PKT_SYNC_SYN            'Y'   // type[1] version[1] sequence[2] time[] sent[] received[]
+#define  ORP_PKT_SYNC_SYNACK         'y'   // type[1] unused[1]  sequence[2] sent[] received[]
+#define  ORP_PKT_SYNC_ACK            'z'   // type[1] unused[1]  sequence[2] sent[] received[]
+
+#define  ORP_PKT_RESP_UNKNOWN_RQST   '?'   // type[1] status[1] pad[2]
+
+
+// Variable length field separator
+#define  ORP_VARLENGTH_SEPARATOR ','   //
+
+
+// Variable length field identifiers
+#define  ORP_FIELD_ID_PATH       'P'   //
+#define  ORP_FIELD_ID_TIME       'T'   //
+#define  ORP_FIELD_ID_UNITS      'U'   //
+#define  ORP_FIELD_ID_DATA       'D'   //
+#define  ORP_FIELD_ID_RECV_COUNT 'R'   //
+#define  ORP_FIELD_ID_SENT_COUNT 'S'   //
+
+
+// Data types
+#define  ORP_DATA_TYPE_TRIGGER   'T'   // trigger - no data
+#define  ORP_DATA_TYPE_BOOLEAN   'B'   // Boolean - 1 byte:  't' | 'f'
+#define  ORP_DATA_TYPE_NUMERIC   'N'   // numeric - null-terminated ASCII string, representing double
+#define  ORP_DATA_TYPE_STRING    'S'   // string  - null-terminated ASCII string
+#define  ORP_DATA_TYPE_JSON      'J'   // JSON    - null-terminated ASCII string, representing JSON
+#define  ORP_DATA_TYPE_UNDEF     ' '   // not specified
+
+
+// Minimum packet length
+#define  ORP_PACKET_LEN_MIN       4    //
+
+
+// Field offsets
+#define  ORP_OFFSET_PACKET_TYPE   0    //
+#define  ORP_OFFSET_DATA_TYPE     1    //
+#define  ORP_OFFSET_SEQ_NUM       2    //
+#define  ORP_OFFSET_VARLENGTH     4    //
+
+#define  ORP_OFFSET_STATUS        1    //
+#define  ORP_OFFSET_VERSION       1    //
+
+
+// Field masks
+#define ORP_MASK_PACK_TYPE        0x0001
+#define ORP_MASK_DATA_TYPE        0x0002
+#define ORP_MASK_SEG_NUM          0x0004
+#define ORP_MASK_SEG_COUNT        0x0008
+#define ORP_MASK_TIME             0x0010
+#define ORP_MASK_PATH             0x0020
+#define ORP_MASK_DATA             0x0040
+#define ORP_MASK_RECV_COUNT       0x0080
+#define ORP_MASK_SENT_COUNT       0x0100
+
+#define ORP_MASK_STATUS           0x0200
+#define ORP_MASK_VERSION          0x0400
+
+
+// Status codes:  Use @-Z (0x40-0x5A) and subtract 0x40
+enum orp_resp_status
+{
+    ORP_RESP_STATUS_OK = 0x40,         // LE_OK = 0
+    ORP_RESP_STATUS_NOT_FOUND,         // LE_NOT_FOUND = -1
+    ORP_RESP_STATUS_NOT_POSSIBLE,      // LE_NOT_POSSIBLE = -2  // DEPRECATED !
+    ORP_RESP_STATUS_OUT_OF_RANGE,      // LE_OUT_OF_RANGE = -3
+    ORP_RESP_STATUS_NO_MEMORY,         // LE_NO_MEMORY = -4
+    ORP_RESP_STATUS_NOT_PERMITTED,     // LE_NOT_PERMITTED = -5
+    ORP_RESP_STATUS_FAULT,             // LE_FAULT = -6
+    ORP_RESP_STATUS_COMM_ERROR,        // LE_COMM_ERROR = -7
+    ORP_RESP_STATUS_TIMEOUT,           // LE_TIMEOUT = -8
+    ORP_RESP_STATUS_OVERFLOW,          // LE_OVERFLOW = -9
+    ORP_RESP_STATUS_UNDERFLOW,         // LE_UNDERFLOW = -10
+    ORP_RESP_STATUS_WOULD_BLOCK,       // LE_WOULD_BLOCK = -11
+    ORP_RESP_STATUS_DEADLOCK,          // LE_DEADLOCK = -12
+    ORP_RESP_STATUS_FORMAT_ERROR,      // LE_FORMAT_ERROR = -13
+    ORP_RESP_STATUS_DUPLICATE,         // LE_DUPLICATE = -14
+    ORP_RESP_STATUS_BAD_PARAMETER,     // LE_BAD_PARAMETER = -15
+    ORP_RESP_STATUS_CLOSED,            // LE_CLOSED = -16
+    ORP_RESP_STATUS_BUSY,              // LE_BUSY = -17
+    ORP_RESP_STATUS_UNSUPPORTED,       // LE_UNSUPPORTED = -18
+    ORP_RESP_STATUS_IO_ERROR,          // LE_IO_ERROR = -19
+    ORP_RESP_STATUS_NOT_IMPLEMENTED,   // LE_NOT_IMPLEMENTED = -20
+    ORP_RESP_STATUS_UNAVAILABLE,       // LE_UNAVAILABLE = -21
+    ORP_RESP_STATUS_TERMINATED,        // LE_TERMINATED = -22
+};
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mapping of encoded to decoded packet types, plus a bitmask of required fields
+ */
+//--------------------------------------------------------------------------------------------------
+static struct
+{
+    uint8_t             encoded;
+    enum orp_PacketType decoded;
+    unsigned int        required;
+}
+orp_PacketTypeTable[] =
+{
+    { ORP_PKT_RQST_INPUT_CREATE,   ORP_RQST_INPUT_CREATE,   ORP_MASK_DATA_TYPE | ORP_MASK_PATH },
+    { ORP_PKT_RESP_INPUT_CREATE,   ORP_RESP_INPUT_CREATE,   ORP_MASK_STATUS                    },
+
+    { ORP_PKT_RQST_OUTPUT_CREATE,  ORP_RQST_OUTPUT_CREATE,  ORP_MASK_DATA_TYPE | ORP_MASK_PATH },
+    { ORP_PKT_RESP_OUTPUT_CREATE,  ORP_RESP_OUTPUT_CREATE,  ORP_MASK_STATUS                    },
+
+    { ORP_PKT_RQST_DELETE,         ORP_RQST_DELETE,         ORP_MASK_PATH                      },
+    { ORP_PKT_RESP_DELETE,         ORP_RESP_DELETE,         ORP_MASK_STATUS                    },
+
+    { ORP_PKT_RQST_HANDLER_ADD,    ORP_RQST_HANDLER_ADD,    ORP_MASK_PATH                      },
+    { ORP_PKT_RESP_HANDLER_ADD,    ORP_RESP_HANDLER_ADD,    ORP_MASK_STATUS                    },
+
+    { ORP_PKT_RQST_HANDLER_REMOVE, ORP_RQST_HANDLER_REM,    ORP_MASK_PATH                      },
+    { ORP_PKT_RESP_HANDLER_REMOVE, ORP_RESP_HANDLER_REM,    ORP_MASK_STATUS                    },
+
+    { ORP_PKT_RQST_PUSH,           ORP_RQST_PUSH,           ORP_MASK_DATA_TYPE | ORP_MASK_PATH },
+    { ORP_PKT_RESP_PUSH,           ORP_RESP_PUSH,           ORP_MASK_STATUS                    },
+
+    { ORP_PKT_RQST_GET,            ORP_RQST_GET,            ORP_MASK_PATH                      },
+    { ORP_PKT_RESP_GET,            ORP_RESP_GET,            ORP_MASK_STATUS                    },
+
+    { ORP_PKT_RQST_EXAMPLE_SET,    ORP_RQST_EXAMPLE_SET,    ORP_MASK_DATA_TYPE | ORP_MASK_PATH },
+    { ORP_PKT_RESP_EXAMPLE_SET,    ORP_RESP_EXAMPLE_SET,    ORP_MASK_STATUS                    },
+
+    { ORP_PKT_RQST_SENSOR_CREATE,  ORP_RQST_SENSOR_CREATE,  ORP_MASK_DATA_TYPE | ORP_MASK_PATH },
+    { ORP_PKT_RESP_SENSOR_CREATE,  ORP_RESP_SENSOR_CREATE,  ORP_MASK_STATUS                    },
+
+    { ORP_PKT_RQST_SENSOR_REMOVE,  ORP_RQST_SENSOR_REMOVE,  ORP_MASK_PATH                      },
+    { ORP_PKT_RESP_SENSOR_REMOVE,  ORP_RESP_SENSOR_REMOVE,  ORP_MASK_STATUS                    },
+
+    { ORP_PKT_NTFY_HANDLER_CALL,   ORP_NTFY_HANDLER_CALL,   ORP_MASK_TIME | ORP_MASK_PATH      },
+    { ORP_PKT_RESP_HANDLER_CALL,   ORP_RESP_HANDLER_CALL,   ORP_MASK_STATUS                    },
+
+    { ORP_PKT_NTFY_SENSOR_CALL,    ORP_NTFY_SENSOR_CALL,    ORP_MASK_PATH                      },
+    { ORP_PKT_RESP_SENSOR_CALL,    ORP_RESP_SENSOR_CALL,    ORP_MASK_STATUS                    },
+
+    { ORP_PKT_SYNC_SYN,            ORP_SYNC_SYN,     /* no mandatory fields for incomming */   },
+    { ORP_PKT_SYNC_SYNACK,         ORP_SYNC_SYNACK,  /* no mandatory fields for incomming */   },
+    { ORP_PKT_SYNC_ACK,            ORP_SYNC_ACK,     /* no mandatory fields for incomming */   },
+
+    { ORP_PKT_RESP_UNKNOWN_RQST,   ORP_RESP_UNKNOWN_RQST,   0                                  },
+
+};
+
+#define ORP_PACKET_TYPE_TABLE_SIZE (sizeof(orp_PacketTypeTable) / sizeof(orp_PacketTypeTable[0]))
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mapping encoded to decoded data types
+ */
+//--------------------------------------------------------------------------------------------------
+static struct
+{
+    uint8_t             encoded;
+    enum orp_IoDataType decoded;
+}
+orp_DataTypeTable[] =
+{
+    { ORP_DATA_TYPE_TRIGGER,  ORP_IO_DATA_TYPE_TRIGGER, },
+    { ORP_DATA_TYPE_BOOLEAN,  ORP_IO_DATA_TYPE_BOOLEAN, },
+    { ORP_DATA_TYPE_NUMERIC,  ORP_IO_DATA_TYPE_NUMERIC, },
+    { ORP_DATA_TYPE_STRING,   ORP_IO_DATA_TYPE_STRING,  },
+    { ORP_DATA_TYPE_JSON,     ORP_IO_DATA_TYPE_JSON,    },
+    { ORP_DATA_TYPE_UNDEF,    ORP_IO_DATA_TYPE_UNDEF,   },
+};
+
+#define ORP_DATA_TYPE_TABLE_SIZE (sizeof(orp_DataTypeTable) / sizeof(orp_DataTypeTable[0]))
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Internal utility to initialize a message structure before decoding into it
+ */
+//--------------------------------------------------------------------------------------------------
+static void orp_MessageInInit
+(
+    struct orp_Message *msg
+)
+//--------------------------------------------------------------------------------------------------
+{
+    static const char * const emptyStr = "";
+
+    memset(msg, 0, sizeof(struct orp_Message));
+    msg->type     = ORP_PACKET_TYPE_UNKNOWN;
+    msg->dataType = ORP_IO_DATA_TYPE_UNDEF;
+    msg->path     = emptyStr;
+    msg->unit     = emptyStr;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Public utility to initialize a message structure before encoding
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_MessageInit
+(
+    struct orp_Message  *msg,
+    enum orp_PacketType  type,
+    unsigned int         status
+)
+//--------------------------------------------------------------------------------------------------
+{
+    memset(msg, 0, sizeof(struct orp_Message));
+    msg->type = type;
+    msg->status = status;
+    msg->timestamp = ORP_TIMESTAMP_INVALID;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Test whether or not a field is required for a given packet type
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_FieldRequired
+(
+    enum orp_PacketType ptype,
+    unsigned int fieldMask
+)
+//--------------------------------------------------------------------------------------------------
+{
+    for (unsigned int i = 0; i < ORP_PACKET_TYPE_TABLE_SIZE; i++)
+    {
+        if (orp_PacketTypeTable[i].decoded == ptype)
+        {
+            return (orp_PacketTypeTable[i].required & fieldMask) ? true : false;
+        }
+    }
+    return false;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Decode the packet type from a packet buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_PacketTypeDecode
+(
+    uint8_t *buf,
+    enum orp_PacketType *ptype
+)
+//--------------------------------------------------------------------------------------------------
+{
+    for (unsigned int i = 0; i < ORP_PACKET_TYPE_TABLE_SIZE; i++)
+    {
+        if (orp_PacketTypeTable[i].encoded == buf[ORP_OFFSET_PACKET_TYPE])
+        {
+            *ptype = orp_PacketTypeTable[i].decoded;
+            return true;
+        }
+    }
+    return false;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode the packet type into a packet buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_PacketTypeEncode
+(
+    uint8_t *buf,
+    enum orp_PacketType ptype
+)
+//--------------------------------------------------------------------------------------------------
+{
+    for (unsigned int i = 0; i < ORP_PACKET_TYPE_TABLE_SIZE; i++)
+    {
+        if (orp_PacketTypeTable[i].decoded == ptype)
+        {
+            buf[ORP_OFFSET_PACKET_TYPE] = orp_PacketTypeTable[i].encoded;
+            return true;
+        }
+    }
+    LE_ERROR("Unrecognized packet type: %d", ptype);
+    return false;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Decode the data type from a packet buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_DataTypeDecode
+(
+    uint8_t             *buf,
+    enum orp_IoDataType *dtype
+)
+//--------------------------------------------------------------------------------------------------
+{
+    *dtype = ORP_IO_DATA_TYPE_UNDEF;
+    for (unsigned int i = 0; i < ORP_DATA_TYPE_TABLE_SIZE; i++)
+    {
+        if (orp_DataTypeTable[i].encoded == buf[ORP_OFFSET_DATA_TYPE])
+        {
+            *dtype = orp_DataTypeTable[i].decoded;
+            return true;
+        }
+    }
+    return false;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode a data type into a packet buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_DataTypeEncode
+(
+    uint8_t            *buf,
+    enum orp_IoDataType dtype
+)
+//--------------------------------------------------------------------------------------------------
+{
+    for (unsigned int i = 0; i < ORP_DATA_TYPE_TABLE_SIZE; i++)
+    {
+        if (orp_DataTypeTable[i].decoded == dtype)
+        {
+            buf[ORP_OFFSET_DATA_TYPE] = orp_DataTypeTable[i].encoded;
+            return true;
+        }
+    }
+    LE_ERROR("Unrecognized data type: %d", dtype);
+    return false;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode the timestamp into a packet buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static size_t orp_TimeEncode
+(
+    uint8_t *buf,
+    size_t   bufLen,
+    double   time
+)
+//--------------------------------------------------------------------------------------------------
+{
+/* FIXME - imorrison 2020:12:02
+ * There is an error in the ORP service which causes it to reject timestamps containing a
+ * decimal point (BROOKLYN-3433).  This will be corrected in release 3.2.0.
+ */
+#if 1
+#define TIME_FMT "%lu"
+    unsigned long sec = time;
+#else
+#define TIME_FMT "%lf"
+    double sec = time;
+#endif
+    return (time == ORP_TIMESTAMP_INVALID) ? 0 : snprintf((char *)buf, bufLen, "%c" TIME_FMT, ORP_FIELD_ID_TIME, sec);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Decode the timestamp from a packet buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_TimeDecode
+(
+    double     *timeVal,
+    const char *timeStr
+)
+//--------------------------------------------------------------------------------------------------
+{
+    bool result = false;
+    bool inDecimal = false;
+
+
+    if (!timeStr)
+    {
+        return false;
+    }
+
+    int len = strnlen(timeStr, ORP_PROTOCOL_TIMESTAMP_LEN_MAX + 1);
+    if (0 == len || len > ORP_PROTOCOL_TIMESTAMP_LEN_MAX)
+    {
+        LE_ERROR("Invalid length time string: %d", len);
+    }
+    else
+    {
+        result = true;
+        for (unsigned int i = 0; i < strlen(timeStr); i++)
+        {
+            if (!isdigit(timeStr[i]))
+            {
+                // One decimal point is fine, any more is obviously wrong
+                if (('.' == timeStr[i]) && (false == inDecimal))
+                {
+                    inDecimal = true;
+                }
+                else
+                {
+                    LE_ERROR("Invalid character in time string: %c", timeStr[i]);
+                    result = false;
+                    break;
+                }
+            }
+        }
+        if (result)
+        {
+            char *endPtr;
+            errno = 0;
+            *timeVal = strtod(timeStr, &endPtr);
+            if (endPtr == timeStr)
+            {
+                LE_ERROR("Failed to decode time string: %s", timeStr);
+                result = false;
+            }
+        }
+    }
+
+    return result;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode the path into a protocol buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static size_t orp_PathEncode
+(
+    uint8_t    *buf,
+    size_t      bufLen,
+    const char *path
+)
+//--------------------------------------------------------------------------------------------------
+{
+    size_t len = 0;
+
+
+    if (path)
+    {
+        len = strlen(path);
+
+        // + 1 for ID byte, no null terminator
+        if (len + 1 > bufLen)
+        {
+            LE_FATAL("Insufficient buffer size %lu", (unsigned long)bufLen);
+        }
+
+        memmove(buf + 1, path, len);
+        *buf = ORP_FIELD_ID_PATH;
+        len++;
+    }
+
+    return len;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode data into a packet
+ */
+//--------------------------------------------------------------------------------------------------
+static size_t orp_DataEncode
+(
+    uint8_t *buf,
+    size_t   bufLen,
+    uint8_t *data,
+    size_t   dataLen
+)
+//--------------------------------------------------------------------------------------------------
+{
+    if (data && dataLen)
+    {
+        // Allow encoding of less than dataLen in order to support multi-packet transactions
+        dataLen = MIN(bufLen - 1, dataLen);
+
+        // + 1 for ID byte, no null terminator
+        memmove(buf + 1, data, dataLen);
+        *buf = ORP_FIELD_ID_DATA;
+        dataLen++;
+    }
+
+    return dataLen;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode the status enum into an ascii packet
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_StatusEncode
+(
+    uint8_t     *buf,
+    unsigned int status
+)
+//--------------------------------------------------------------------------------------------------
+{
+    buf[ORP_OFFSET_STATUS] = (uint8_t)((int)ORP_RESP_STATUS_OK - (int)status);
+    return true;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode the status enum into an ascii packet
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_StatusDecode
+(
+    uint8_t      *buf,
+    unsigned int *status
+)
+//--------------------------------------------------------------------------------------------------
+{
+    *status = (unsigned int)((int)ORP_RESP_STATUS_OK - (int)buf[ORP_OFFSET_STATUS]);
+    return true;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode the protocol version into an ascii packet
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_VersionEncode
+(
+    uint8_t *buf,
+    uint8_t  version
+)
+//--------------------------------------------------------------------------------------------------
+{
+    if (version <= 9)
+    {
+        buf[ORP_OFFSET_VERSION] = '0' + version;
+    }
+    else if (10 <= version && version <= 15)
+    {
+        buf[ORP_OFFSET_VERSION] = 'A' + (version - 10);
+    }
+    else
+    {
+        return false;
+    }
+    return true;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode the second byte of a packet, according to the packet type
+ *
+ * Request:  data type
+ * Response: status
+ * Sync:     version number
+ *
+ * @note: Message type field must be valid
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_PacketByte1Encode
+(
+    uint8_t            *buf,
+    struct orp_Message *msg
+)
+//--------------------------------------------------------------------------------------------------
+{
+    // SYN | SYNACK | ACK
+    if (   (ORP_SYNC_SYN    == msg->type)
+        || (ORP_SYNC_SYNACK == msg->type)
+        || (ORP_SYNC_ACK    == msg->type))
+    {
+        if (!orp_VersionEncode(buf, ORP_PROTOCOL_V2))
+        {
+            return false;
+        }
+    }
+    // Response
+    else if (ORP_RESPONSE_MASK & msg->type)
+    {
+        if (!orp_StatusEncode(buf, msg->status))
+        {
+            return false;
+        }
+    }
+    // Request
+    else
+    {
+        if (!orp_DataTypeEncode(buf, msg->dataType))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Decode the second byte of a packet, according to the packet type
+ *
+ * Request:  data type
+ * Response: status
+ * Sync:     version number
+ *
+ * @note: Message type field must be valid
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_PacketByte1Decode
+(
+    uint8_t            *buf,
+    struct orp_Message *msg
+)
+//--------------------------------------------------------------------------------------------------
+{
+    bool status = true;
+
+    // SYN | SYNACK | ACK
+    if (   (ORP_SYNC_SYN    == msg->type)
+        || (ORP_SYNC_SYNACK == msg->type)
+        || (ORP_SYNC_ACK    == msg->type))
+    {
+        LE_ERROR("SYN|SYNACK|ACK byte 1 not decoded");
+//            break;
+    }
+    // Response
+    else if (ORP_RESPONSE_MASK & msg->type)
+    {
+        status = orp_StatusDecode(buf, &msg->status);
+    }
+    // Request
+    else
+    {
+        // Data Type is not mandatory for all packets
+        if (orp_FieldRequired(msg->type, ORP_MASK_DATA_TYPE))
+        {
+            status = orp_DataTypeDecode(buf, &msg->dataType);
+        }
+    }
+
+    if (!status)
+    {
+        LE_ERROR("Failed to decode packet byte 1: %c", buf[1]);
+    }
+    return status;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode the sent count into a protocol buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static size_t orp_SentCountEncode
+(
+    uint8_t *buf,
+    size_t   bufLen,
+    int      count
+)
+//--------------------------------------------------------------------------------------------------
+{
+    return (count < 0) ? 0 : snprintf((char *)buf, bufLen, "%c%d", ORP_FIELD_ID_SENT_COUNT, count);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode the received count into a protocol buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static size_t orp_ReceivedCountEncode
+(
+    uint8_t *buf,
+    size_t   bufLen,
+    int      count
+)
+//--------------------------------------------------------------------------------------------------
+{
+    return (count < 0) ? 0 : snprintf((char *)buf, bufLen, "%c%d", ORP_FIELD_ID_RECV_COUNT, count);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Decode a request from a buffer formatted according to version 1 of the protocol
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_ProtocolDecode_v1
+(
+    uint8_t            *pktBuf,
+    size_t              pktLen,
+    struct orp_Message *msg
+)
+//--------------------------------------------------------------------------------------------------
+{
+    enum { SEARCH, INFIELD, DONE, ERROR } state = ERROR;
+    const char *timeStr = NULL;
+
+
+    LE_ASSERT(pktBuf && msg);
+
+    do
+    {
+        if (pktLen < ORP_PACKET_LEN_MIN)
+        {
+            LE_ERROR("Packet too short: %lu", (unsigned long)pktLen);
+            break;
+        }
+
+        orp_MessageInInit(msg);
+
+        // Fixed length fields
+        if (!orp_PacketTypeDecode(pktBuf, &msg->type))
+        {
+            LE_ERROR("Failed to decode packet type: %d", msg->type);
+            break;
+        }
+        if (!orp_PacketByte1Decode(pktBuf, msg))
+        {
+            break;
+        }
+        msg->sequenceNum = (pktBuf[ORP_OFFSET_SEQ_NUM] << 8) & 0xFF00;
+        msg->sequenceNum += pktBuf[ORP_OFFSET_SEQ_NUM + 1] & 0x00FF;
+
+        /* Locate and parse variable length fields
+         * Variable length fields must begin with an identifier byte
+         */
+        state = SEARCH;
+        for (unsigned int i = ORP_OFFSET_VARLENGTH;
+             i < pktLen && state != DONE && state != ERROR; i++)
+        {
+            // If separator found, null-terminate current field and scan for next
+            if (ORP_VARLENGTH_SEPARATOR == pktBuf[i])
+            {
+                pktBuf[i] = '\0';
+                state = SEARCH;
+                continue;
+            }
+
+            if (SEARCH == state)
+            {
+                char *endPtr;
+
+                switch (pktBuf[i])
+                {
+                    case ORP_FIELD_ID_PATH:
+                        msg->path = (const char *)&pktBuf[i + 1];
+                        state = INFIELD;
+                        break;
+
+                    case ORP_FIELD_ID_TIME:
+                        timeStr = (const char *)&pktBuf[i + 1];
+                        state = INFIELD;
+                        break;
+
+                    case ORP_FIELD_ID_UNITS:
+                        msg->unit = (const char *)&pktBuf[i + 1];
+                        state = INFIELD;
+                        break;
+
+                    case ORP_FIELD_ID_DATA:
+                        msg->data = &pktBuf[i + 1];
+                        msg->dataLen = pktLen - i - 1;
+                        pktBuf[pktLen] = '\0';
+                        // Data must be last field - Stop scanning immediately
+                        state = DONE;
+                        break;
+
+                    case ORP_FIELD_ID_RECV_COUNT:
+                        state = INFIELD;
+                        errno = 0;
+                        msg->receivedCount = strtoul((const char *)&pktBuf[i + 1], &endPtr, 0);
+                        if (0 != errno)
+                        {
+                            LE_ERROR("Failed to decode received count");
+                            state = ERROR;
+                        }
+                        break;
+
+                    case ORP_FIELD_ID_SENT_COUNT:
+                        state = INFIELD;
+                        errno = 0;
+                        msg->sentCount = strtoul((const char *)&pktBuf[i + 1], &endPtr, 0);
+                        if (0 != errno)
+                        {
+                            LE_ERROR("Failed to decode sent count");
+                            state = ERROR;
+                        }
+                        break;
+
+                    default:
+                        LE_ERROR("Unknown field identifier pktBuf[%d] = %02X", i, pktBuf[i]);
+                        state = ERROR;
+                        break;
+                }
+            }
+        }
+
+        /* Ensure that the last byte beyond the reported packet length is null.  This is to
+         * null-terminate the last field, as there is no separator at the end.  Doing this will
+         * not affect (binary) data as long as the packet size is not incremented
+         */
+        pktBuf[pktLen] = '\0';
+
+        // Convert the string timestamp to double, if present.  Done here to ensure string is null terminated
+        if (timeStr && strlen(timeStr))
+        {
+            orp_TimeDecode(&msg->timestamp, timeStr);
+        }
+
+        if (ERROR == state)
+        {
+            LE_ERROR("Failed to decode: %d %d %04X %s",
+                     msg->type, msg->dataType, msg->sequenceNum,
+                     pktBuf + ORP_OFFSET_VARLENGTH);
+        }
+        else
+        {
+            LE_DEBUG("Decoded: %u %d %04X path: %s time: %lf unit: %s dataLen: %lu",
+                     msg->type, msg->dataType, msg->sequenceNum,
+                     msg->path ? msg->path : "",
+                     msg->timestamp,
+                     msg->unit ? msg->unit : "",
+                     (unsigned long)msg->dataLen);
+        }
+
+    } while (0);
+
+    return ERROR == state ? false : true;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Encode an outgoing response according to version 1 of the protocol and load it into a buffer
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_ProtocolEncode_v1
+(
+    uint8_t            *packet,
+    size_t             *packetLen,
+    struct orp_Message *msg
+)
+//--------------------------------------------------------------------------------------------------
+{
+    size_t len;
+    bool result = false;
+
+
+    LE_ASSERT(packet && packetLen && msg);
+
+    do
+    {
+        len = *packetLen;
+        if (len < ORP_PACKET_LEN_MIN)
+        {
+            LE_ERROR("Buffer too short: %zu", len);
+            break;
+        }
+
+        memset(packet, 0, len);
+
+        // Encode fixed-length fields
+        if (!orp_PacketTypeEncode(packet, msg->type))
+        {
+            break;
+        }
+        if (!orp_PacketByte1Encode(packet, msg))
+        {
+            break;
+        }
+        packet[ORP_OFFSET_SEQ_NUM]     = (msg->sequenceNum & 0x00FF);
+        packet[ORP_OFFSET_SEQ_NUM + 1] = (msg->sequenceNum & 0xFF00) >> 8;
+
+        /* Encode variable length fields, starting at ORP_OFFSET_VARLENGTH.
+         * Insert separators only as needed
+         */
+        size_t index = ORP_OFFSET_VARLENGTH;
+        size_t fieldLen = 0;
+
+        fieldLen = orp_TimeEncode(packet + index, len - index, msg->timestamp);
+        index += fieldLen;
+
+        // Append path if provided.  Note: zero length is permitted
+        if (msg->path)
+        {
+            if (fieldLen)
+            {
+                packet[index++] = ',';
+            }
+            fieldLen = orp_PathEncode(packet + index, len - index, msg->path);
+            index += fieldLen;
+        }
+
+        // Append data if provided.  Zero length will be omitted
+        if (msg->dataLen)
+        {
+            if (fieldLen)
+            {
+                packet[index++] = ',';
+            }
+            fieldLen = orp_DataEncode(packet + index, len - index, msg->data, msg->dataLen);
+            index += fieldLen;
+            msg->dataLen -= fieldLen;
+        }
+
+        // Version 2: Append send and received counts if this is a sync packet
+        if (ORP_SYNC_SYN == msg->type)
+        {
+            if (msg->sentCount >= 0)
+            {
+                if (fieldLen)
+                {
+                    packet[index++] = ',';
+                }
+                fieldLen = orp_SentCountEncode(packet + index, len - index, msg->sentCount);
+                index += fieldLen;
+            }
+            if (msg->receivedCount >= 0)
+            {
+                if (fieldLen)
+                {
+                    packet[index++] = ',';
+                }
+                fieldLen = orp_ReceivedCountEncode(packet + index, len - index, msg->receivedCount);
+                index += fieldLen;
+            }
+        }
+
+        *packetLen = index;
+        result = true;
+
+    } while (0);
+
+    return result;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Initialize protocol interface
+ */
+//--------------------------------------------------------------------------------------------------
+bool orp_ProtocolClientInit
+(
+    enum orp_ProtocolVersion  version,
+    struct orp_ProtocolCodec *codecs
+)
+//--------------------------------------------------------------------------------------------------
+{
+    bool status = false;
+
+
+    LE_ASSERT(codecs);
+
+    switch (version)
+    {
+        case ORP_PROTOCOL_V1:
+        case ORP_PROTOCOL_V2:
+            codecs->decode = orp_ProtocolDecode_v1;
+            codecs->encode = orp_ProtocolEncode_v1;
+            status = true;
+            break;
+
+        default:
+            break;
+    }
+
+    return status;
+}

--- a/clients/c/src/orpProtocol.c
+++ b/clients/c/src/orpProtocol.c
@@ -457,9 +457,8 @@ static size_t orp_TimeEncode
 )
 //--------------------------------------------------------------------------------------------------
 {
-/* FIXME - imorrison 2020:12:02
- * There is an error in the ORP service which causes it to reject timestamps containing a
- * decimal point (BROOKLYN-3433).  This will be corrected in release 3.2.0.
+/* NOTE: There is an error in the ORP service which causes it to reject timestamps containing a
+ * decimal point.  This will be corrected in Octave firmware release 3.2.0.
  */
 #if 1
 #define TIME_FMT "%lu"

--- a/clients/c/src/orpUtils.c
+++ b/clients/c/src/orpUtils.c
@@ -1,0 +1,148 @@
+/**
+ * @file:    orpUtils.c
+ *
+ * Purpose:  Utility functions for the Octave Resource Protocol
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include "orpUtils.h"
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Print the fields of an ORP message structure (template)
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_MessagePrint
+(
+    struct orp_Message *message
+)
+{
+    static struct
+    {
+        enum orp_PacketType type;
+        const char *name;
+    } packetNames[] = {
+        { ORP_PACKET_TYPE_UNKNOWN, "Unknown packet type" },
+        { ORP_RQST_INPUT_CREATE,   "Request, input create" },
+        { ORP_RESP_INPUT_CREATE,   "Response, input create" },
+        { ORP_RQST_OUTPUT_CREATE,  "Request, output create" },
+        { ORP_RESP_OUTPUT_CREATE,  "Response, output create" },
+        { ORP_RQST_DELETE,         "Request, delete" },
+        { ORP_RESP_DELETE,         "Response, delete" },
+        { ORP_RQST_HANDLER_ADD,    "Request, handler add" },
+        { ORP_RESP_HANDLER_ADD,    "Response, handler add" },
+        { ORP_RQST_HANDLER_REM,    "Request, handler remove" },
+        { ORP_RESP_HANDLER_REM,    "Response, handler remove" },
+        { ORP_RQST_PUSH,           "Request, push" },
+        { ORP_RESP_PUSH,           "Response, push" },
+        { ORP_RQST_GET,            "Request, get" },
+        { ORP_RESP_GET,            "Response, get" },
+        { ORP_RQST_EXAMPLE_SET,    "Request, set example" },
+        { ORP_RESP_EXAMPLE_SET,    "Response, set example" },
+        { ORP_RQST_SENSOR_CREATE,  "Request, sensor create" },
+        { ORP_RESP_SENSOR_CREATE,  "Response, sensor create" },
+        { ORP_RQST_SENSOR_REMOVE,  "Request, sensor remove" },
+        { ORP_RESP_SENSOR_REMOVE,  "Response, sensor remove" },
+        { ORP_NTFY_HANDLER_CALL,   "Notification, handler called" },
+        { ORP_RESP_HANDLER_CALL,   "Response, handler called" },
+        { ORP_NTFY_SENSOR_CALL,    "Notification, sensor call" },
+        { ORP_RESP_SENSOR_CALL,    "Response, sensor call" },
+        { ORP_SYNC_SYN,            "Synchronization, sync" },
+        { ORP_SYNC_SYNACK,         "Synchronization, sync-ack" },
+        { ORP_SYNC_ACK,            "Synchronization, ack" },
+        { ORP_RESP_UNKNOWN_RQST,   "Response, unknown request" },
+    };
+
+    const char *statusStr[] = {
+        "OK",
+        "Item does not exist or could not be found",
+        "Not possible to perform the requested action",
+        "An index or other value is out of range",
+        "Insufficient memory is available",
+        "Current user does not have permission to perform requested action",
+        "Unspecified internal error",
+        "Communications error",
+        "A time-out occurred",
+        "An overflow occurred or would have occurred",
+        "An underflow occurred or would have occurred",
+        "Would have blocked if non-blocking behaviour was not requested",
+        "Would have caused a deadlock",
+        "Format error",
+        "Duplicate entry found or operation already performed",
+        "Parameter is invalid",
+        "The resource is closed",
+        "The resource is busy",
+        "The underlying resource does not support this operation",
+        "An IO operation failed",
+        "Unimplemented functionality",
+        "A transient or temporary loss of a service or resource",
+        "The process, operation, data stream, session, etc. has stopped",
+        "The operation is in progress",
+        "The operation is suspended",
+    };
+
+    const char *packetName = "Unknown";
+    for (int i = 0; i < (sizeof(packetNames) / sizeof(packetNames[0])); i++)
+    {
+        if (message->type == packetNames[i].type)
+        {
+            packetName = packetNames[i].name;
+            break;
+        }
+    }
+    printf("\tType     : %d (%s)\n", message->type, packetName);
+    if (   (message->type !=ORP_NTFY_HANDLER_CALL)
+        && (message->type !=ORP_NTFY_SENSOR_CALL))
+    {
+        if (message->type & ORP_RESPONSE_MASK)
+        {
+            printf("\tStatus   : %d (%s)\n", (int)message->status, statusStr[message->status * -1]);
+        }
+        else
+        {
+            printf("\tData type: %d\n", message->dataType);
+        }
+    }
+    printf("\tSequence : %u\n", message->sequenceNum);
+    if (message->timestamp > 0.0)
+    {
+        printf("\tTimestamp: %lf\n", message->timestamp);
+    }
+    if (message->path && strlen(message->path))
+    {
+        printf("\tPath     : %s\n", message->path);
+    }
+    if (message->data && message->dataLen)
+    {
+        printf("\tData     : %s\n", (char *)message->data);
+    }
+}


### PR DESCRIPTION
Resolves: BROOKLYN-3456

This change contains sample C code and a command-line client for ORP.  The code is intended to be used as:
a) Example code to help users in writing an ORP client
b) A utility for becoming familar with ORP 

The protocol encoding/decoding routines (orpProtocol.c) and the HDLC framing/unframing routines (hdlc.c) are shared with the ORP server implementation on the Octave devices.  This should help to ensure good compatiblity with Octave.

Once approved, this change will be upstreamed to https://github.com/SierraWireless/octave-orp

**Testing:**
See attached file

[BROOKLYN-3456_Tests.txt](https://github.com/SierraWireless/octave-orp/files/5656077/BROOKLYN-3456_Tests.txt)
