### PR TITLE
ORP - C Client - Error reported when SYNC packet received

### DIFF
--- a/clients/c/src/orpClient.c
+++ b/clients/c/src/orpClient.c
@@ -294,6 +294,32 @@ err:
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Respond to a sync packet
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t orp_Respond
+(
+    enum orp_PacketType type,
+    int status
+)
+{
+    struct orp_Message message;
+
+    switch (type)
+    {
+        case ORP_RESP_HANDLER_CALL: break;
+        case ORP_RESP_SENSOR_CALL: break;
+        case ORP_SYNC_SYNACK: break;
+        case ORP_SYNC_ACK: break;
+        default: return LE_BAD_PARAMETER;
+    }
+    orp_MessageInit(&message, type, status);
+    return orp_ClientMessageSend(&message);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Handle an incomimg message
  */
 //--------------------------------------------------------------------------------------------------
@@ -302,7 +328,44 @@ static void orp_Dispatch
     struct orp_Message *message
 )
 {
-    // nothing implemented yet
+    switch(message->type)
+    {
+        case ORP_PACKET_TYPE_UNKNOWN:
+        case ORP_RQST_INPUT_CREATE:
+        case ORP_RESP_INPUT_CREATE:
+        case ORP_RQST_OUTPUT_CREATE:
+        case ORP_RESP_OUTPUT_CREATE:
+        case ORP_RQST_DELETE:
+        case ORP_RESP_DELETE:
+        case ORP_RQST_HANDLER_ADD:
+        case ORP_RESP_HANDLER_ADD:
+        case ORP_RQST_HANDLER_REM:
+        case ORP_RESP_HANDLER_REM:
+        case ORP_RQST_PUSH:
+        case ORP_RESP_PUSH:
+        case ORP_RQST_GET:
+        case ORP_RESP_GET:
+        case ORP_RQST_EXAMPLE_SET:
+        case ORP_RESP_EXAMPLE_SET:
+        case ORP_RQST_SENSOR_CREATE:
+        case ORP_RESP_SENSOR_CREATE:
+        case ORP_RQST_SENSOR_REMOVE:
+        case ORP_RESP_SENSOR_REMOVE:
+        case ORP_NTFY_HANDLER_CALL:
+        case ORP_RESP_HANDLER_CALL:
+        case ORP_NTFY_SENSOR_CALL:
+        case ORP_RESP_SENSOR_CALL:
+            break;
+
+        case ORP_SYNC_SYN:
+            (void)orp_Respond(ORP_SYNC_SYNACK, );
+            break;
+
+        case ORP_SYNC_SYNACK:
+        case ORP_SYNC_ACK:
+        case ORP_RESP_UNKNOWN_RQST:
+        default:
+    }
 }
 
 

--- a/clients/c/src/orpProtocol.c
+++ b/clients/c/src/orpProtocol.c
@@ -617,7 +617,7 @@ static bool orp_StatusEncode
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Encode the status enum into an ascii packet
+ * Decode the status byte from a packet
  */
 //--------------------------------------------------------------------------------------------------
 static bool orp_StatusDecode
@@ -651,6 +651,36 @@ static bool orp_VersionEncode
     else if (10 <= version && version <= 15)
     {
         buf[ORP_OFFSET_VERSION] = 'A' + (version - 10);
+    }
+    else
+    {
+        return false;
+    }
+    return true;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Decode the protocol version from an ascii packet
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_VersionDecode
+(
+    uint8_t *buf,
+    short int *version
+)
+//--------------------------------------------------------------------------------------------------
+{
+    char c = toupper(buf[ORP_OFFSET_VERSION]);
+    
+    if ('0' <= c || c <= '9')
+    {
+        *version = c - '0';
+    }
+    else if ('A' <= c || c <= 'F')
+    {
+        *version = c - 'A' + 10;
     }
     else
     {
@@ -733,8 +763,7 @@ static bool orp_PacketByte1Decode
         || (ORP_SYNC_SYNACK == msg->type)
         || (ORP_SYNC_ACK    == msg->type))
     {
-        LE_ERROR("SYN|SYNACK|ACK byte 1 not decoded");
-//            break;
+        status = orp_VersionDecode(buf, &msg->version);
     }
     // Response
     else if (ORP_RESPONSE_MASK & msg->type)


### PR DESCRIPTION
Added decoding of SYNC packet to C client example

Resolves: BROOKLYN-3489
Signed-off-by: imorrison <imorrison@sierrawireless.com>

Testing:
```
imorrison@carmd-ed-11193:~/ws/imorrisonca/octave-orp/clients/c$ ./bin/orp -d /dev/ttyUSB3 -b 115200
ORP Serial Client - "h" for help, "q" to exit
using device: /dev/ttyUSB3, Baud: 115200
Protocol codec initialized
                                                     
orp >  
Received: 'Y13031T1607992228.000000', (28 bytes)                                                          
        Type     : 13 (Synchronization, sync)                                                             
        Data type: -1
        Sequence : 12337                            
        Timestamp: 1607992228.000000            

orp > r synack
Sending: '~y1205~', (8 bytes)
        Type     : 14 (Synchronization, sync-ack)
        Data type: 0
        Sequence : 2
```