### PR TITLE
Added decoding of SYNC packet to C client example

### DIFF
--- a/clients/c/src/orpProtocol.c
+++ b/clients/c/src/orpProtocol.c
@@ -617,7 +617,7 @@ static bool orp_StatusEncode
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Encode the status enum into an ascii packet
+ * Decode the status byte from a packet
  */
 //--------------------------------------------------------------------------------------------------
 static bool orp_StatusDecode
@@ -651,6 +651,36 @@ static bool orp_VersionEncode
     else if (10 <= version && version <= 15)
     {
         buf[ORP_OFFSET_VERSION] = 'A' + (version - 10);
+    }
+    else
+    {
+        return false;
+    }
+    return true;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Decode the protocol version from an ascii packet
+ */
+//--------------------------------------------------------------------------------------------------
+static bool orp_VersionDecode
+(
+    uint8_t *buf,
+    short int *version
+)
+//--------------------------------------------------------------------------------------------------
+{
+    char c = toupper(buf[ORP_OFFSET_VERSION]);
+    
+    if ('0' <= c || c <= '9')
+    {
+        *version = c - '0';
+    }
+    else if ('A' <= c || c <= 'F')
+    {
+        *version = c - 'A' + 10;
     }
     else
     {
@@ -733,8 +763,7 @@ static bool orp_PacketByte1Decode
         || (ORP_SYNC_SYNACK == msg->type)
         || (ORP_SYNC_ACK    == msg->type))
     {
-        LE_ERROR("SYN|SYNACK|ACK byte 1 not decoded");
-//            break;
+        status = orp_VersionDecode(buf, &msg->version);
     }
     // Response
     else if (ORP_RESPONSE_MASK & msg->type)


### PR DESCRIPTION

Resolves BROOKLYN-3489
Signed-off-by: imorrison <imorrison@sierrawireless.com>

Testing:
```
imorrison@carmd-ed-11193:~/ws/imorrisonca/octave-orp/clients/c$ ./bin/orp -d /dev/ttyUSB3 -b 115200
ORP Serial Client - "h" for help, "q" to exit
using device: /dev/ttyUSB3, Baud: 115200
Protocol codec initialized
                                                     
orp >  
Received: 'Y13031T1607992228.000000', (28 bytes)                                                          
        Type     : 13 (Synchronization, sync)                                                             
        Data type: -1
        Sequence : 12337                            
        Timestamp: 1607992228.000000            

orp > r synack
Sending: '~y1205~', (8 bytes)
        Type     : 14 (Synchronization, sync-ack)
        Data type: 0
        Sequence : 2
```