### PR TITLE
BROOKLYN-3824 - Add support for File Transfer to C client sample code

### DIFF
--- a/clients/c/Makefile
+++ b/clients/c/Makefile
@@ -35,7 +35,7 @@ CLI_TOOL := orp
 
 CFLAGS = -I$(INC_DIR)
 
-SRCS := main.c commands.c orpProtocol.c hdlc.c orpClient.c orpUtils.c
+SRCS := main.c commands.c orpProtocol.c hdlc.c orpClient.c orpUtils.c orpFile.c
 OBJS := $(addprefix $(BUILD_DIR)/,$(patsubst %.c,%.o,$(SRCS)))
 
 

--- a/clients/c/inc/fileTransfer.h
+++ b/clients/c/inc/fileTransfer.h
@@ -1,0 +1,16 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * File transfer event types
+ */
+//--------------------------------------------------------------------------------------------------
+enum fileTransferEventE
+{
+    FILETRANSFER_EVENT_INFO,                ///< Informational (ignored by ORP service)
+    FILETRANSFER_EVENT_READY,               ///< Client ready for file transfer
+    FILETRANSFER_EVENT_PENDING,             ///< Transfer pending
+    FILETRANSFER_EVENT_START,               ///< File transfer start
+    FILETRANSFER_EVENT_SUSPEND,             ///< File transfer suspend
+    FILETRANSFER_EVENT_RESUME,              ///< File transfer resume
+    FILETRANSFER_EVENT_COMPLETE,            ///< File transfer complete
+    FILETRANSFER_EVENT_ABORT,               ///< File transfer aborted
+};

--- a/clients/c/inc/orpClient.h
+++ b/clients/c/inc/orpClient.h
@@ -184,4 +184,43 @@ int orp_Respond
     int status
 );
 
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Send a sync packet
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_SyncSend
+(
+    enum orp_PacketType type,
+    int version,
+    int sentCount,
+    int recvCount,
+    int mtu
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Send a file transfer notification (a control message)
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_FileTransferNotify
+(
+    unsigned int status,
+    const char *controlData
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Send file transfer data
+ */
+//--------------------------------------------------------------------------------------------------
+int orp_FileTransferData
+(
+    unsigned int status,
+    const char *fileData
+);
+
 #endif // ORP_CLIENT_H_INCLUDE_GUARD

--- a/clients/c/inc/orpFile.h
+++ b/clients/c/inc/orpFile.h
@@ -1,0 +1,100 @@
+/**
+ * @file:    orpFile.h
+ *
+ * Purpose:  File transfer utility for the Octave Resource Protocol
+ *
+ * MIT License
+ *
+ * Copyright (c) 2021 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ */
+
+#ifndef ORP_FILE_H_INCLUDE_GUARD
+#define ORP_FILE_H_INCLUDE_GUARD
+
+#include "orpProtocol.h"
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum file name length
+ */
+//--------------------------------------------------------------------------------------------------
+#define FILE_NAME_MAX_LEN   128
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Function to set the auto mode
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_FileTransferSetAuto
+(
+    bool isAuto                 ///< [IN] Is auto mode set ?
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Function to check if the auto mode is activated
+ */
+//--------------------------------------------------------------------------------------------------
+bool orp_FileTransferGetAuto
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Setup data storage for inbound file transfer
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_FileDataSetup
+(
+    char   *namePtr,
+    size_t  fileSize,
+    bool    isAuto
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Save or cache inbound file data
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_FileDataCache
+(
+    void   *dataPtr,
+    size_t  dataLen
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Flush saved data from RAM to the file
+ * To be called when the user acks a file data packet.  Does nothing if auto mode is active
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_FileDataFlush
+(
+    void
+);
+
+#endif // ORP_FILE_H_INCLUDE_GUARD

--- a/clients/c/inc/orpProtocol.h
+++ b/clients/c/inc/orpProtocol.h
@@ -100,6 +100,8 @@
                                          + ORP_PROTOCOL_UNITS_LEN_MAX \
                                          + ORP_PROTOCOL_TIMESTAMP_LEN_MAX )
 
+// Minimum size which a frame must support
+#define ORP_PROTOCOL_FRAME_LEN_MIN      128
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -119,7 +121,7 @@ enum orp_ProtocolVersion
  * Packet types
  */
 //--------------------------------------------------------------------------------------------------
-#define ORP_RESPONSE_MASK 0x10
+#define ORP_RESPONSE_MASK 0x80
 enum orp_PacketType
 {
     ORP_PACKET_TYPE_UNKNOWN = 0,
@@ -164,6 +166,12 @@ enum orp_PacketType
     ORP_SYNC_SYNACK         = 14,
     ORP_SYNC_ACK            = 15,
 
+    ORP_RQST_FILE_DATA      = 16,
+    ORP_RESP_FILE_DATA      = ORP_RQST_FILE_DATA     | ORP_RESPONSE_MASK,
+
+    ORP_NTFY_FILE_CONTROL   = 17,
+    ORP_RESP_FILE_CONTROL   = ORP_NTFY_FILE_CONTROL  | ORP_RESPONSE_MASK,
+
     ORP_RESP_UNKNOWN_RQST   = 128                    | ORP_RESPONSE_MASK,
 };
 
@@ -193,10 +201,12 @@ enum orp_IoDataType
 struct orp_Message
 {
     enum orp_PacketType         type;          ///< Type of ORP packet
+    // TODO - Consider using a union for mutually exclusive fields (minor savings)
     enum orp_IoDataType         dataType;      ///< Data type of resource
+    int                         version;       ///< Protocol version (sync packets only)
+    int                         status;        ///< Status of a response
+
     uint16_t                    sequenceNum;   ///< Number of this packet (16-bit rollover)
-    short                       version;       ///< Protocol version (sync packets only)
-    unsigned int                status;        ///< Status of a response
     double                      timestamp;     ///< Timestamp read/write
     const char                 *path;          ///< Resource path
     const char                 *unit;          ///< Resource units
@@ -204,6 +214,7 @@ struct orp_Message
     size_t                      dataLen;       ///< Data length
     int                         sentCount;     ///< Sent packet count (sync packets only)
     int                         receivedCount; ///< Received packet count (sync packets only)
+    int                         mtu;           ///< Maximum transfer unit (sync packets only)
 };
 
 #define  ORP_TIMESTAMP_INVALID   ((double)(-1))

--- a/clients/c/src/main.c
+++ b/clients/c/src/main.c
@@ -119,6 +119,7 @@ void processIO(void)
                         printf("Exiting\n");
                         break;
                     }
+                    printf("\norp > ");
                 }
             }
             if (fds[1].revents & POLLIN)
@@ -130,7 +131,6 @@ void processIO(void)
                 printf("Received POLLHUP from %s. Exiting\n", devStr);
                 break;
             }
-            printf("\norp > ");
             fflush(stdout);
         }
         // send preamble byte to keep USB awake
@@ -150,7 +150,10 @@ speed_t baudGet(char *baudStr)
         baud = B38400;
     else if (0 == strcmp("57600", baudStr))
         baud = B57600;
-
+    else if (0 == strcmp("460800", baudStr))
+        baud = B460800;
+    else if (0 == strcmp("921600", baudStr))
+        baud = B921600;
     return baud;
 }
 

--- a/clients/c/src/orpFile.c
+++ b/clients/c/src/orpFile.c
@@ -1,0 +1,298 @@
+/**
+ * @file:    orpFile.c
+ *
+ * Purpose:  File transfer utility for the Octave Resource Protocol
+ *
+ * MIT License
+ *
+ * Copyright (c) 2021 Sierra Wireless Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *----------------------------------------------------------------------------
+ *
+ * NOTES:
+ *
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include "orpFile.h"
+#include "legato.h"
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum data to be read
+ */
+//--------------------------------------------------------------------------------------------------
+#define FILE_DATA_MAX_LEN   (100 * 1024)
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Static for auto mode
+ */
+//--------------------------------------------------------------------------------------------------
+static int AutoMode = false;
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Static for file name
+ */
+//--------------------------------------------------------------------------------------------------
+static char FileName[FILE_NAME_MAX_LEN] = {0};
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Static buffer for incoming file data
+ */
+//--------------------------------------------------------------------------------------------------
+static uint8_t IncomingFileData[FILE_DATA_MAX_LEN];
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Static for incoming file data length
+ */
+//--------------------------------------------------------------------------------------------------
+static size_t IncomingFileDataLen = 0;
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Total bytes received for the current file
+ */
+//--------------------------------------------------------------------------------------------------
+static size_t ReceivedFileBytes = 0;
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Total bytes expected for the current file
+ */
+//--------------------------------------------------------------------------------------------------
+static ssize_t ExpectedFileBytes = -1;
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Function to set the file name (from the 'file control start/auto <filename>' command)
+ */
+//--------------------------------------------------------------------------------------------------
+static void FileTransferSetName
+(
+    char* namePtr               ///< [IN] File name
+)
+{
+    int fd;
+
+    if (!namePtr)
+    {
+        LE_ERROR("Invalid file name");
+        return;
+    }
+
+    snprintf(FileName, FILE_NAME_MAX_LEN, "%s", namePtr);
+
+    // Check if a file already exists
+    fd = open(FileName, O_RDONLY);
+    if (fd != -1)
+    {
+        close(fd);
+        // The file already exists, delete it
+        unlink(namePtr);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Function to write data to the file
+ * Each time this function is called, the file is opened/created, updated and closed
+ */
+//--------------------------------------------------------------------------------------------------
+ssize_t FileDataWrite
+(
+    void*   dataPtr,            ///< [IN] Data pointer
+    size_t  dataLen             ///< [IN] Data length
+)
+{
+    if (strlen(FileName) && dataLen && dataPtr)
+    {
+        // Open the file, create it if it does not exist
+        int fd = open(FileName, O_WRONLY | O_APPEND | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+        if (fd == -1)
+        {
+            perror("Cannot open output file\n");
+            return -1;
+        }
+
+        ssize_t len = 0;
+        while (len < dataLen)
+        {
+            ssize_t temp = write(fd, dataPtr + len, dataLen - len);
+            if (temp == -1)
+            {
+                printf("Failed to write data: Error %s\n", strerror(errno));
+            }
+            else
+            {
+                len += temp;
+            }
+        }
+
+        if (-1 == close(fd))
+        {
+            printf("Failed to close file: Error %s\n", strerror(errno));
+        }
+        return len;
+    }
+
+    return -1;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Function to keep data in RAM before storing it
+ * This is used if auto mode is not set
+ */
+//--------------------------------------------------------------------------------------------------
+void FileDataKeep
+(
+    void*   dataPtr,            ///< [IN] Data pointer
+    size_t  dataLen             ///< [IN] Data length
+)
+{
+    if (!dataPtr)
+    {
+        return;
+    }
+
+    memset(IncomingFileData, 0, FILE_DATA_MAX_LEN);
+    memcpy(IncomingFileData, dataPtr, dataLen);
+    IncomingFileDataLen = dataLen;
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Function to set the auto mode
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_FileTransferSetAuto
+(
+    bool isAuto                 ///< [IN] Is auto mode set ?
+)
+{
+    AutoMode = isAuto;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Function to check if the auto mode is activated
+ */
+//--------------------------------------------------------------------------------------------------
+bool orp_FileTransferGetAuto
+(
+    void
+)
+{
+    return AutoMode;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Setup data storage for inbound file transfer
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_FileDataSetup
+(
+    char   *namePtr,
+    size_t  fileSize,
+    bool    isAuto
+)
+{
+    FileTransferSetName(namePtr);
+    AutoMode = isAuto;
+    ReceivedFileBytes = 0;
+    ExpectedFileBytes = fileSize;
+
+    IncomingFileDataLen = 0;
+    memset(IncomingFileData, 0, FILE_DATA_MAX_LEN);
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Save or cache inbound file data
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_FileDataCache
+(
+    void   *dataPtr,
+    size_t  dataLen
+)
+{
+    ssize_t writtenLen = -1;
+
+
+    if (AutoMode)
+    {
+        writtenLen = FileDataWrite(dataPtr, dataLen);
+    }
+    else
+    {
+        FileDataKeep(dataPtr, dataLen);
+        writtenLen = dataLen;
+    }
+
+    if (writtenLen != -1)
+    {
+        ReceivedFileBytes += dataLen;
+    }
+    else
+    {
+        printf("Failed to write data\n");
+    }
+
+    // Once all bytes are received, disable auto mode
+    if ((ExpectedFileBytes > 0) && (ReceivedFileBytes >= ExpectedFileBytes))
+    {
+        AutoMode = false;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Flush saved data from RAM to the file
+ * To be called when the user acks a file data packet.  Does nothing if auto mode is active
+ */
+//--------------------------------------------------------------------------------------------------
+void orp_FileDataFlush
+(
+    void
+)
+{
+    if (!AutoMode && IncomingFileDataLen)
+    {
+        FileDataWrite(IncomingFileData, IncomingFileDataLen);
+        IncomingFileDataLen = 0;
+        memset(IncomingFileData, 0, FILE_DATA_MAX_LEN);
+    }
+}


### PR DESCRIPTION
BROOKLYN-3824 - Add support for File Transfer to C client sample code

- Added commands: file control, reply data, sync
- Added option to send sync packets with optional MTU
- Added functionality to save downloaded files
- Added auto reply option to file control start
- Added support for BAUD rates: 460800 and 921600

Resolves:  BROOKLYN-3824
author imorrison <imorrison@sierrawireless.com> 
Co-authored-by fdur <fdur@sierrawireless.com> 