### PR TITLE
Add support for AT-commands based HL78xx

### DIFF
--- a/clients/python/modules/orp_protocol.py
+++ b/clients/python/modules/orp_protocol.py
@@ -649,7 +649,7 @@ def decode_response(response):
         # Positional fields:
         ptype      = chr(response[0])
         status_ver = response[1]
-        seq_num    = int(response[2:4])
+        seq_num    = int.from_bytes(response[2:4], "big")
         # Labeled, variable length fields
         var_length = (response[4:len(response)]).decode("utf-8")
         print('Received     : ' + chr(response[0]) + chr(response[1]) + chr(response[2]) + chr(response[3]) + var_length)

--- a/clients/python/modules/simple_at.py
+++ b/clients/python/modules/simple_at.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+# coding: utf8
+
+# License posted here: https://github.com/wuttem/simple-hdlc/blob/master/LICENSE
+# and copied below:
+#
+# MIT License
+#
+# Copyright (c) 2016 wuttem
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+__version__ = '0.3'
+
+import sys
+import logging
+import time
+from threading import Thread
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+logger.addHandler(ch)
+
+
+def bin_to_hex(b):
+    if sys.version_info[0] == 2:
+        return b.encode("hex")
+    return b.hex()
+
+
+class OrpAtCmdHandler(object):
+    def __init__(self, serial, reset=True):
+        self.serial = serial
+        self.frame_callback = None
+        # self.error_callback = None
+        self.running = False
+        logger.debug("OrpAtCmdHandler init: %s bytes in buffer", self.serial.in_waiting)
+        if reset:
+            self.serial.reset_input_buffer()
+
+    def sendFrame(self, data):
+        bs = self._encode(data)
+        logger.info("Sending bytearray: %s", bs)
+        logger.debug("Sending Frame: %s", bin_to_hex(bs))
+        res = self.serial.write(bs)
+        logger.debug("Send %s bytes", res)
+
+    def _onFrame(self, frame):
+        logger.debug("Received bytearray: %s", frame)
+        logger.debug("Received Frame: %s", bin_to_hex(frame))
+        if self.frame_callback is not None:
+            self.frame_callback(frame)
+
+    # def _onError(self, frame):
+    #     logger.warning("Frame Error: %s", bin_to_hex(frame))
+    #     if self.error_callback is not None:
+    #         self.error_callback(frame)
+
+    @classmethod
+    def _encode(cls, bs):
+        return b"AT+ORP=\"" + bs + b"\"\r\n"
+
+    @classmethod
+    def _decode(cls, bs):
+        if bs.startswith(b"AT+ORP=\""):
+            decoded_bs =bs[8:-1]
+            logger.debug(f"Decoded echo bytearray: {decoded_bs}")
+            return None
+        if bs.startswith(b"+ORP: "):
+            logger.info("Received reply bytearray: %s", bs)
+            decoded_bs =bs[6:]
+            logger.debug(f"Decoded reply bytearray: {decoded_bs}")
+            return decoded_bs
+        logger.debug(f"Failed to decode received bytearray: {bs}")
+        return None
+
+    def _receiveLoop(self):
+        while self.running:
+            i = self.serial.in_waiting
+            if i < 1:
+                time.sleep(0.001)
+                continue
+            bs = self.serial.readline()
+            logger.debug("Received bytearray: %s", bs)
+            decoded_data = self._decode(bs)
+            if decoded_data is not None:
+                self._onFrame(decoded_data)
+
+    def startReader(self, onFrame, onError=None):
+        if self.running:
+            raise RuntimeError("reader already running")
+        self.reader = Thread(target=self._receiveLoop)
+        self.reader.setDaemon(True)
+        self.frame_callback = onFrame
+        self.error_callback = onError
+        self.running = True
+        self.reader.start()
+
+    def stopReader(self):
+        self.running = False
+        self.reader.join()
+        self.reader = None

--- a/clients/python/orp_at_test.py
+++ b/clients/python/orp_at_test.py
@@ -1,0 +1,160 @@
+#============================================================================
+#
+# Filename:  orp_at_test.py
+#
+# Purpose:   Python test script to send and receive AT framed commands
+#            using the Octave Resource Protocol
+#
+# MIT License
+#
+# Copyright (c) 2020 Sierra Wireless Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#----------------------------------------------------------------------------
+#
+# NOTES:
+#
+# 1. Install Python 3.x
+#
+# 2. Install the following, using pip3:
+#
+#    Windows:
+#    > pip3 install six pyserial
+#
+#    Linux
+#    > sudo -H pip3 install six pyserial
+#
+import logging
+import threading
+from time import sleep
+import argparse
+
+import serial
+
+import modules.orp_protocol as orp_protocol
+from modules.orp_protocol import decode_response
+from modules.orp_protocol import encode_request
+from modules.simple_at import OrpAtCmdHandler
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+logger.addHandler(ch)
+
+#
+# Function to automatically reply to sync
+#
+def sync_acknowledge(data):
+    checkPacket = chr(data[0])
+
+    if orp_protocol.ORP_PKT_SYNC_SYN == checkPacket or orp_protocol.ORP_PKT_SYNC_SYNACK == checkPacket:
+        request = 'r y 0'
+        packet = encode_request(request)
+        h.sendFrame(packet.encode())
+        print('\nService Restarted\nConnected\n>')
+
+    if orp_protocol.ORP_PKT_NTFY_HANDLER_CALL == checkPacket or orp_protocol.ORP_PKT_RESP_HANDLER_CALL == checkPacket:
+        request = 'r C 0'
+        packet = encode_request(request)
+        h.sendFrame(packet.encode())
+        print('\nAcknowledged push notification\n>')
+
+    if orp_protocol.ORP_PKT_NTFY_SENSOR_CALL == checkPacket or orp_protocol.ORP_PKT_RESP_SENSOR_CALL == checkPacket:
+        request = 'r B 0'
+        packet = encode_request(request)
+        h.sendFrame(packet.encode())
+        print('\nAcknowledged sensor notification\n>')
+
+
+#
+# Callback to receive and decode incoming frames
+#
+def frame_callback(data):
+    try:
+        decode_response(data)
+        if auto_ack is True:
+            sync_acknowledge(data)
+    except Exception as e:
+        logger.error(f"Caught exception <{e}> in frame_callback: exiting...")
+        keep_alive_event.clear()
+        raise
+
+
+# =========================================================================== #
+
+#
+# Arguments
+#
+parser = argparse.ArgumentParser(description='Octave Resource Protocol Client Test Script',
+                                 usage="orp_test.py [-h] --dev DEV [--b BAUD] [--no-auto-ack]\n"
+		                               "Where:\n"
+                                       "  DEV is the serial port (e.g. COM3 on Windows or /dev/ttyUSB0 on Linux)\n"
+                                       "  BAUD is the baudrate (example 115200, default value is 9600)\n")
+parser.add_argument('--dev', help='serial device port (example COM3 on Windows or /dev/ttyUSB0 on Linux)', required=True )
+parser.add_argument('--b', help='baudrate of serial port. Example 9600, default value is 115200')
+parser.add_argument('--no-auto-ack', help='Disable automatic responses', action='store_false', required=False, default=True)
+args = parser.parse_args()
+
+dev = args.dev
+baud = 115200
+auto_ack = True
+if args.b:
+    baud = args.b
+if args.no_auto_ack is False:
+    auto_ack = False
+
+#
+# UART configuration
+#
+# Using the default: 8/N/1
+s = serial.Serial(port=dev, baudrate=baud, timeout=0.5)
+keep_alive_event = threading.Event()
+
+h = OrpAtCmdHandler(s)
+h.startReader(onFrame=frame_callback)
+keep_alive_event.set()
+
+print('ORP Serial Client - "q" to exit')
+print('using device: ' + dev + ', speed: ' + baud + ', 8N1')
+if auto_ack is False:
+    print('auto-acknowledgements disabled')
+print('enter commands\n')
+
+while keep_alive_event.is_set():
+    request = input('> ')
+    if request == 'q':
+        print('exiting')
+        keep_alive_event.clear()
+        break
+
+    # remove trailing whitespace
+    request = request.rstrip()
+
+    if request != "":
+        packet = encode_request(request)
+        if packet is not None:
+            s0 = ord(packet[2])
+            s1 = ord(packet[3])
+            packet = packet[0] + packet[1] + str(s0) + str(s1) + packet[4:]
+            logger.debug(f"Sending ORP payload: {packet}")
+            h.sendFrame(packet.encode())
+            sleep(1)


### PR DESCRIPTION
Hello,

I have been using HL78xx development kit. To avoid implementing the ORP protocol support, I did reuse your implementation of ORP protocol by removing the HDLC protocol and replacing it by AT command support. This is only for the Python client (note that I dropped support for Python2...).

A small improvement has also been added : when an unexpected exception occurs the program will exit instead of keeping running as it was confusing for me to still be able to enter commands.

It would be nice if this can be included officially in the project.