### PR TITLE
Incorrect sequence number incoding in the C client

### DIFF
--- a/clients/c/src/orpClient.c
+++ b/clients/c/src/orpClient.c
@@ -90,9 +90,6 @@ static int fd = -1;
 // HDLC context
 static hdlc_context_t rxHdlcContext;
 
-// Count of the number of frames transmitted so far.  This will roll-over
-static uint16_t sequenceNum = 0;
-
 //--------------------------------------------------------------------------------------------------
 /**
  * Initialize local variables and state
@@ -115,7 +112,7 @@ bool orp_ClientInit
     }
     printf("Protocol codec initialized\n");
     fd = fileDescriptor;
-    sequenceNum = 0;
+
     if (mode == MODE_HDLC)
     {
         hdlc_Init(&rxHdlcContext);
@@ -280,17 +277,6 @@ static le_result_t orp_ClientMessageSend
     size_t   packetBufferLen = sizeof(txPacketBuf);
     uint8_t *frameBuffer = txFrameBuf;
     size_t   frameBufferSize = sizeof(txFrameBuf);
-    bool     syncMessage = false;
-
-    // Set sequence number if this is anything other than a sync packet
-    if (ORP_SYNC_SYN == message->type || ORP_SYNC_SYNACK == message->type || ORP_SYNC_ACK == message->type)
-    {
-        syncMessage = true;
-    }
-    else
-    {
-        message->sequenceNum = sequenceNum;
-    }
 
     // Encode the packet
     if (!orp_Encode(packetBuffer, &packetBufferLen, message))
@@ -333,10 +319,6 @@ static le_result_t orp_ClientMessageSend
         goto err;
     }
 
-    if (!syncMessage)
-    {
-        sequenceNum++;
-    }
     return LE_OK;
 
 err:

--- a/clients/c/src/orpProtocol.c
+++ b/clients/c/src/orpProtocol.c
@@ -270,6 +270,7 @@ orp_PacketTypeTable[] =
 
 #define ORP_PACKET_TYPE_TABLE_SIZE (sizeof(orp_PacketTypeTable) / sizeof(orp_PacketTypeTable[0]))
 
+static uint16_t last_received_seq_number = 0;
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -937,8 +938,10 @@ static bool orp_ProtocolDecode_v1
             offset = ORP_OFFSET_DATA_TYPE;
             break;
         }
-        msg->sequenceNum = (pktBuf[ORP_OFFSET_SEQ_NUM] << 8) & 0xFF00;
-        msg->sequenceNum += pktBuf[ORP_OFFSET_SEQ_NUM + 1] & 0x00FF;
+
+        last_received_seq_number = (pktBuf[ORP_OFFSET_SEQ_NUM] << 8) & 0xFF00;
+        last_received_seq_number += pktBuf[ORP_OFFSET_SEQ_NUM + 1] & 0x00FF;
+        msg->sequenceNum = last_received_seq_number;
 
         /* Locate and parse variable length fields
          * Variable length fields must begin with an identifier byte
@@ -1109,8 +1112,17 @@ static bool orp_ProtocolEncode_v1
         {
             break;
         }
-        packet[ORP_OFFSET_SEQ_NUM]     = (msg->sequenceNum & 0x00FF);
-        packet[ORP_OFFSET_SEQ_NUM + 1] = (msg->sequenceNum & 0xFF00) >> 8;
+
+        // Copy Sequence Number from Request or increment it in case of request sent by the device
+        if ((packet[ORP_OFFSET_PACKET_TYPE] != ORP_PKT_SYNC_SYN) && isupper(packet[ORP_OFFSET_PACKET_TYPE]))
+        {
+            // The device will send a request -> increment the Sequence Number
+            last_received_seq_number += 1;
+        }
+
+        packet[ORP_OFFSET_SEQ_NUM]     = (last_received_seq_number & 0xFF00) >> 8;
+        packet[ORP_OFFSET_SEQ_NUM + 1] = (last_received_seq_number & 0x00FF);
+        msg->sequenceNum = last_received_seq_number;
 
         /* Encode variable length fields, starting at ORP_OFFSET_VARLENGTH.
          * Insert separators only as needed

--- a/clients/c/src/orpProtocol.c
+++ b/clients/c/src/orpProtocol.c
@@ -939,6 +939,7 @@ static bool orp_ProtocolDecode_v1
             break;
         }
 
+        // Sequence number is encoded in Big-Endian
         last_received_seq_number = (pktBuf[ORP_OFFSET_SEQ_NUM] << 8) & 0xFF00;
         last_received_seq_number += pktBuf[ORP_OFFSET_SEQ_NUM + 1] & 0x00FF;
         msg->sequenceNum = last_received_seq_number;
@@ -1113,16 +1114,19 @@ static bool orp_ProtocolEncode_v1
             break;
         }
 
+        uint16_t sequence_number_to_send = last_received_seq_number;
+
         // Copy Sequence Number from Request or increment it in case of request sent by the device
         if ((packet[ORP_OFFSET_PACKET_TYPE] != ORP_PKT_SYNC_SYN) && isupper(packet[ORP_OFFSET_PACKET_TYPE]))
         {
             // The device will send a request -> increment the Sequence Number
-            last_received_seq_number += 1;
+            sequence_number_to_send = last_received_seq_number + 1;
         }
 
-        packet[ORP_OFFSET_SEQ_NUM]     = (last_received_seq_number & 0xFF00) >> 8;
-        packet[ORP_OFFSET_SEQ_NUM + 1] = (last_received_seq_number & 0x00FF);
-        msg->sequenceNum = last_received_seq_number;
+        // Sequence number is encoded in Big-Endian
+        packet[ORP_OFFSET_SEQ_NUM]     = (sequence_number_to_send & 0xFF00) >> 8;
+        packet[ORP_OFFSET_SEQ_NUM + 1] = (sequence_number_to_send & 0x00FF);
+        msg->sequenceNum = sequence_number_to_send;
 
         /* Encode variable length fields, starting at ORP_OFFSET_VARLENGTH.
          * Insert separators only as needed


### PR DESCRIPTION
Fix some issues in sequence number in the C client:
- Increment the sequence number when the C client sends an ORP request to the edge
- Sequence number decoding from big-endian